### PR TITLE
Add created_at and modified_at timestamps to dependency metadata

### DIFF
--- a/actions/upload-metadata/action.yml
+++ b/actions/upload-metadata/action.yml
@@ -37,11 +37,23 @@ runs:
     - id: upload
       shell: bash
       run: |
-        #!/usr/bin/inputs bash
         set -euo pipefail
 
         filename="$(echo '${{ inputs.dependency-name }}' | awk '{print tolower($0)}')"
         aws s3 cp "s3://${{ inputs.bucket-name }}/metadata/${filename}.json" metadata.json
+
+        now="$(date '+%FT%T%:z')"
+
+        created_at=
+        original_created_at="$(jq \
+          --arg version "${{ inputs.version }}" \
+          -r '.[] | select(.version == $version) | .created_at // ""' metadata.json)"
+
+        if [[ -n "${original_created_at}" ]]; then
+          created_at="${original_created_at}"
+        else
+          created_at="${now}"
+        fi
 
         metadata="$(cat << EOF
         {
@@ -52,12 +64,17 @@ runs:
           "stacks": ${{ inputs.stacks }},
           "source": "${{ inputs.source-uri }}",
           "source_sha256": "${{ inputs.source-sha256 }}",
-          "deprecation_date": "${{ inputs.deprecation-date }}"
+          "deprecation_date": "${{ inputs.deprecation-date }}",
+          "created_at": "${created_at}",
+          "modified_at": "${now}"
         }
         EOF
         )"
 
-        updated_metadata="$(jq --argjson metadata "${metadata}" --arg version "${{ inputs.version }}" -r 'del(.[] | select(.version == $version)) | [$metadata] + .' metadata.json)"
+        updated_metadata="$(jq \
+          --argjson metadata "${metadata}" \
+          --arg version "${{ inputs.version }}" \
+          -r 'del(.[] | select(.version == $version)) | [$metadata] + .' metadata.json)"
 
         echo "${updated_metadata}" > metadata.json
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Adds timestamps to dependency metadata representing the first build as well as the most recent build.

## Use Cases
This allows us to track how long it takes us to build dependencies from the time they were released upstream.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
