### PR TITLE
Use *time.Time for timestamps

### DIFF
--- a/actions/get-upstream-dependency/action.yml
+++ b/actions/get-upstream-dependency/action.yml
@@ -50,9 +50,9 @@ runs:
         )"
 
         echo "::set-output name=uri::$(jq -r .uri <<< "${metadata}")"
-        echo "::set-output name=sha256::$(jq -r .sha <<< "${metadata}")"
-        echo "::set-output name=release-date::$(jq -r .release_date <<< "${metadata}")"
-        echo "::set-output name=deprecation-date::$(jq -r .deprecation_date <<< "${metadata}")"
+        echo "::set-output name=sha256::$(jq -r .sha256 <<< "${metadata}")"
+        echo "::set-output name=release-date::$(jq -r '.release_date // empty' <<< "${metadata}")"
+        echo "::set-output name=deprecation-date::$(jq -r '.deprecation_date // empty' <<< "${metadata}")"
         echo "::set-output name=cpe::$(jq -r .cpe <<< "${metadata}")"
 
         rm -f ./entrypoint

--- a/actions/get-upstream-dependency/entrypoint/go.sum
+++ b/actions/get-upstream-dependency/entrypoint/go.sum
@@ -2,12 +2,16 @@ github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3Q
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sclevine/spec v1.4.0 h1:z/Q9idDcay5m5irkZ28M7PtQM4aOISzOpj4bUPkDee8=
 github.com/sclevine/spec v1.4.0/go.mod h1:LvpgJaFyvQzRvc1kaDs0bulYwzC70PbiYjC4QnFHkOM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -20,6 +24,8 @@ golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXR
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b h1:QRR6H1YWRnHb4Y/HeNFCTJLFVxaq6wH4YuVdsUOr75U=
+gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=

--- a/actions/get-upstream-dependency/entrypoint/main.go
+++ b/actions/get-upstream-dependency/entrypoint/main.go
@@ -4,8 +4,9 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency"
 	"os"
+
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency"
 )
 
 func main() {

--- a/actions/get-upstream-dependency/entrypoint/main_test.go
+++ b/actions/get-upstream-dependency/entrypoint/main_test.go
@@ -2,16 +2,18 @@ package main_test
 
 import (
 	"encoding/json"
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency"
-	"github.com/sclevine/spec"
-
-	"github.com/sclevine/spec/report"
-	assertpkg "github.com/stretchr/testify/assert"
-	requirepkg "github.com/stretchr/testify/require"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"testing"
+
+	"github.com/sclevine/spec"
+
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency"
+
+	"github.com/sclevine/spec/report"
+	assertpkg "github.com/stretchr/testify/assert"
+	requirepkg "github.com/stretchr/testify/require"
 )
 
 func TestEntrypoint(t *testing.T) {

--- a/actions/list-new-upstream-dependency-versions/entrypoint/go.sum
+++ b/actions/list-new-upstream-dependency-versions/entrypoint/go.sum
@@ -2,6 +2,9 @@ github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3Q
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sclevine/spec v1.4.0 h1:z/Q9idDcay5m5irkZ28M7PtQM4aOISzOpj4bUPkDee8=
@@ -20,6 +23,7 @@ golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXR
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=

--- a/actions/list-new-upstream-dependency-versions/entrypoint/main.go
+++ b/actions/list-new-upstream-dependency-versions/entrypoint/main.go
@@ -4,8 +4,9 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency"
 	"os"
+
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency"
 )
 
 func main() {

--- a/pkg/dependency/bundler.go
+++ b/pkg/dependency/bundler.go
@@ -55,7 +55,7 @@ func (b Bundler) GetDependencyVersion(version string) (DepVersion, error) {
 			return DepVersion{
 				Version:         version,
 				URI:             depURL,
-				SHA:             release.SHA,
+				SHA256:          release.SHA,
 				ReleaseDate:     &releaseDate,
 				DeprecationDate: nil,
 				CPE:             fmt.Sprintf("cpe:2.3:a:bundler:bundler:%s:*:*:*:*:ruby:*:*", version),

--- a/pkg/dependency/bundler.go
+++ b/pkg/dependency/bundler.go
@@ -48,12 +48,16 @@ func (b Bundler) GetDependencyVersion(version string) (DepVersion, error) {
 
 	for _, release := range bundlerReleases {
 		if release.Version == version {
+			releaseDate, err := time.Parse(time.RFC3339Nano, release.Date)
+			if err != nil {
+				return DepVersion{}, fmt.Errorf("could not parse release date: %w", err)
+			}
 			return DepVersion{
 				Version:         version,
 				URI:             depURL,
 				SHA:             release.SHA,
-				ReleaseDate:     release.Date,
-				DeprecationDate: "",
+				ReleaseDate:     &releaseDate,
+				DeprecationDate: nil,
 				CPE:             fmt.Sprintf("cpe:2.3:a:bundler:bundler:%s:*:*:*:*:ruby:*:*", version),
 			}, nil
 		}
@@ -62,23 +66,23 @@ func (b Bundler) GetDependencyVersion(version string) (DepVersion, error) {
 	return DepVersion{}, fmt.Errorf("could not find version %s", version)
 }
 
-func (b Bundler) GetReleaseDate(version string) (time.Time, error) {
+func (b Bundler) GetReleaseDate(version string) (*time.Time, error) {
 	bundlerReleases, err := b.getAllReleases()
 	if err != nil {
-		return time.Time{}, fmt.Errorf("could not get releases: %w", err)
+		return nil, fmt.Errorf("could not get releases: %w", err)
 	}
 
 	for _, release := range bundlerReleases {
 		if release.Version == version {
 			releaseDate, err := time.Parse(time.RFC3339Nano, release.Date)
 			if err != nil {
-				return time.Time{}, fmt.Errorf("could not parse release date: %w", err)
+				return nil, fmt.Errorf("could not parse release date: %w", err)
 			}
-			return releaseDate, nil
+			return &releaseDate, nil
 		}
 	}
 
-	return time.Time{}, fmt.Errorf("could not find release date for version %s", version)
+	return nil, fmt.Errorf("could not find release date for version %s", version)
 }
 
 func (b Bundler) getAllReleases() ([]BundlerRelease, error) {

--- a/pkg/dependency/bundler_test.go
+++ b/pkg/dependency/bundler_test.go
@@ -274,7 +274,7 @@ func testBundler(t *testing.T, when spec.G, it spec.S) {
 			expectedDepVersion := dependency.DepVersion{
 				Version:         "2.1.3",
 				URI:             "https://rubygems.org/downloads/bundler-2.1.3.gem",
-				SHA:             "9b9a9a5685121403eda1ae148ed3a34c86418f2a2beec7df82a45d4baca0e5d2",
+				SHA256:          "9b9a9a5685121403eda1ae148ed3a34c86418f2a2beec7df82a45d4baca0e5d2",
 				ReleaseDate:     &expectedReleaseDate,
 				DeprecationDate: nil,
 				CPE:             "cpe:2.3:a:bundler:bundler:2.1.3:*:*:*:*:ruby:*:*",

--- a/pkg/dependency/bundler_test.go
+++ b/pkg/dependency/bundler_test.go
@@ -1,14 +1,16 @@
 package dependency_test
 
 import (
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency"
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency/dependencyfakes"
+	"testing"
+	"time"
+
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
-	"time"
+
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency"
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency/dependencyfakes"
 )
 
 func TestBundler(t *testing.T) {
@@ -268,12 +270,13 @@ func testBundler(t *testing.T, when spec.G, it spec.S) {
 			actualDepVersion, err := bundler.GetDependencyVersion("2.1.3")
 			require.NoError(err)
 
+			expectedReleaseDate := time.Date(2020, 01, 02, 12, 29, 43, 745000000, time.UTC)
 			expectedDepVersion := dependency.DepVersion{
 				Version:         "2.1.3",
 				URI:             "https://rubygems.org/downloads/bundler-2.1.3.gem",
 				SHA:             "9b9a9a5685121403eda1ae148ed3a34c86418f2a2beec7df82a45d4baca0e5d2",
-				ReleaseDate:     "2020-01-02T12:29:43.745Z",
-				DeprecationDate: "",
+				ReleaseDate:     &expectedReleaseDate,
+				DeprecationDate: nil,
 				CPE:             "cpe:2.3:a:bundler:bundler:2.1.3:*:*:*:*:ruby:*:*",
 			}
 			assert.Equal(expectedDepVersion, actualDepVersion)

--- a/pkg/dependency/caapm.go
+++ b/pkg/dependency/caapm.go
@@ -61,13 +61,13 @@ func (c CAAPM) GetDependencyVersion(version string) (DepVersion, error) {
 		Version:         version,
 		URI:             dependencyURL,
 		SHA:             dependencySHA,
-		ReleaseDate:     "",
-		DeprecationDate: "",
+		ReleaseDate:     nil,
+		DeprecationDate: nil,
 	}, nil
 }
 
-func (c CAAPM) GetReleaseDate(version string) (time.Time, error) {
-	return time.Time{}, fmt.Errorf("cannot determine release dates for CAAPM")
+func (c CAAPM) GetReleaseDate(_ string) (*time.Time, error) {
+	return nil, fmt.Errorf("cannot determine release dates for CAAPM")
 }
 
 func (c CAAPM) dependencyURL(version string) string {

--- a/pkg/dependency/caapm.go
+++ b/pkg/dependency/caapm.go
@@ -2,12 +2,13 @@ package dependency
 
 import (
 	"fmt"
-	"github.com/Masterminds/semver"
 	"io/ioutil"
 	"path/filepath"
 	"regexp"
 	"sort"
 	"time"
+
+	"github.com/Masterminds/semver"
 )
 
 type CAAPM struct {
@@ -60,7 +61,7 @@ func (c CAAPM) GetDependencyVersion(version string) (DepVersion, error) {
 	return DepVersion{
 		Version:         version,
 		URI:             dependencyURL,
-		SHA:             dependencySHA,
+		SHA256:          dependencySHA,
 		ReleaseDate:     nil,
 		DeprecationDate: nil,
 	}, nil

--- a/pkg/dependency/caapm_test.go
+++ b/pkg/dependency/caapm_test.go
@@ -79,7 +79,7 @@ func testCAAPM(t *testing.T, when spec.G, it spec.S) {
 			expectedDepVersion := dependency.DepVersion{
 				Version:         "20.1.0",
 				URI:             "https://ca.bintray.com/apm-agents/CA-APM-PHPAgent-20.1.0_linux.tar.gz",
-				SHA:             "some-source-sha",
+				SHA256:          "some-source-sha",
 				ReleaseDate:     nil,
 				DeprecationDate: nil,
 			}

--- a/pkg/dependency/caapm_test.go
+++ b/pkg/dependency/caapm_test.go
@@ -1,13 +1,15 @@
 package dependency_test
 
 import (
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency"
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency/dependencyfakes"
+	"testing"
+
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
+
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency"
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency/dependencyfakes"
 )
 
 func TestCAAPM(t *testing.T) {
@@ -78,8 +80,8 @@ func testCAAPM(t *testing.T, when spec.G, it spec.S) {
 				Version:         "20.1.0",
 				URI:             "https://ca.bintray.com/apm-agents/CA-APM-PHPAgent-20.1.0_linux.tar.gz",
 				SHA:             "some-source-sha",
-				ReleaseDate:     "",
-				DeprecationDate: "",
+				ReleaseDate:     nil,
+				DeprecationDate: nil,
 			}
 
 			assert.Equal(expectedDepVersion, actualDepVersion)

--- a/pkg/dependency/composer.go
+++ b/pkg/dependency/composer.go
@@ -2,10 +2,12 @@ package dependency
 
 import (
 	"fmt"
-	"github.com/Masterminds/semver"
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency/internal"
 	"strings"
 	"time"
+
+	"github.com/Masterminds/semver"
+
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency/internal"
 )
 
 type Composer struct {
@@ -77,7 +79,7 @@ func (c Composer) createDependencyVersion(release internal.GithubRelease) (DepVe
 	return DepVersion{
 		Version:         release.TagName,
 		URI:             c.dependencyURL(release.TagName),
-		SHA:             sha,
+		SHA256:          sha,
 		ReleaseDate:     &release.PublishedDate,
 		DeprecationDate: nil,
 	}, nil
@@ -87,11 +89,11 @@ func (c Composer) getDependencySHA(version string) (string, error) {
 	shaUrl := c.shaURL(version)
 	body, err := c.webClient.Get(shaUrl)
 	if err != nil {
-		return "", fmt.Errorf("could not download composer SHA file: %w", err)
+		return "", fmt.Errorf("could not download composer SHA256 file: %w", err)
 	}
 	depSHA := strings.Split(string(body), " ")[0]
 	if len(depSHA) < 64 {
-		return "", fmt.Errorf("could not get SHA from file %s", shaUrl)
+		return "", fmt.Errorf("could not get SHA256 from file %s", shaUrl)
 	}
 	return depSHA, nil
 }

--- a/pkg/dependency/composer.go
+++ b/pkg/dependency/composer.go
@@ -54,23 +54,19 @@ func (c Composer) GetDependencyVersion(version string) (DepVersion, error) {
 	return DepVersion{}, fmt.Errorf("could not find composer version %s", version)
 }
 
-func (c Composer) GetReleaseDate(version string) (time.Time, error) {
+func (c Composer) GetReleaseDate(version string) (*time.Time, error) {
 	releases, err := c.githubClient.GetReleaseTags("composer", "composer")
 	if err != nil {
-		return time.Time{}, fmt.Errorf("could not get releases: %w", err)
+		return nil, fmt.Errorf("could not get releases: %w", err)
 	}
 
 	for _, release := range releases {
 		if release.TagName == version {
-			releaseDate, err := time.Parse(time.RFC3339, release.PublishedDate)
-			if err != nil {
-				return time.Time{}, fmt.Errorf("could not parse release date: %w", err)
-			}
-			return releaseDate, nil
+			return &release.PublishedDate, nil
 		}
 	}
 
-	return time.Time{}, fmt.Errorf("could not find release date for version %s", version)
+	return nil, fmt.Errorf("could not find release date for version %s", version)
 }
 
 func (c Composer) createDependencyVersion(release internal.GithubRelease) (DepVersion, error) {
@@ -82,8 +78,8 @@ func (c Composer) createDependencyVersion(release internal.GithubRelease) (DepVe
 		Version:         release.TagName,
 		URI:             c.dependencyURL(release.TagName),
 		SHA:             sha,
-		ReleaseDate:     release.PublishedDate,
-		DeprecationDate: "",
+		ReleaseDate:     &release.PublishedDate,
+		DeprecationDate: nil,
 	}, nil
 }
 

--- a/pkg/dependency/composer_test.go
+++ b/pkg/dependency/composer_test.go
@@ -1,15 +1,17 @@
 package dependency_test
 
 import (
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency"
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency/dependencyfakes"
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency/internal"
+	"testing"
+	"time"
+
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
-	"time"
+
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency"
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency/dependencyfakes"
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency/internal"
 )
 
 func TestComposer(t *testing.T) {
@@ -112,7 +114,7 @@ func testComposer(t *testing.T, when spec.G, it spec.S) {
 			expectedDep := dependency.DepVersion{
 				Version:         "1.0.1",
 				URI:             "https://getcomposer.org/download/1.0.1/composer.phar",
-				SHA:             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				SHA256:          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				ReleaseDate:     &expectedReleaseDate,
 				DeprecationDate: nil,
 			}
@@ -123,7 +125,7 @@ func testComposer(t *testing.T, when spec.G, it spec.S) {
 			assert.Equal("composer", repoArg)
 		})
 
-		when("the SHA cannot be found", func() {
+		when("the SHA256 cannot be found", func() {
 			it("returns an error", func() {
 				fakeGithubClient.GetReleaseTagsReturns([]internal.GithubRelease{
 					{
@@ -136,7 +138,7 @@ func testComposer(t *testing.T, when spec.G, it spec.S) {
 				_, err := composer.GetDependencyVersion("3.0.0")
 				assert.Error(err)
 
-				assert.Contains(err.Error(), "could not get SHA from file")
+				assert.Contains(err.Error(), "could not get SHA256 from file")
 			})
 		})
 	})

--- a/pkg/dependency/composer_test.go
+++ b/pkg/dependency/composer_test.go
@@ -40,38 +40,39 @@ func testComposer(t *testing.T, when spec.G, it spec.S) {
 
 	when("GetAllVersionRefs", func() {
 		it("returns all composer final release versions with newest versions first", func() {
+			time.Date(2020, 06, 30, 0, 0, 0, 0, time.UTC)
 			fakeGithubClient.GetReleaseTagsReturns([]internal.GithubRelease{
 				{
 					TagName:       "3.0.0",
-					PublishedDate: "2020-06-30T00:00:00Z",
+					PublishedDate: time.Date(2020, 06, 30, 0, 0, 0, 0, time.UTC),
 				},
 				{
 					TagName:       "3.0.0-RC",
-					PublishedDate: "2020-06-29T00:00:00Z",
+					PublishedDate: time.Date(2020, 06, 29, 0, 0, 0, 0, time.UTC),
 				},
 				{
 					TagName:       "3.0.0-beta1",
-					PublishedDate: "2020-06-29T00:00:00Z",
+					PublishedDate: time.Date(2020, 06, 29, 0, 0, 0, 0, time.UTC),
 				},
 				{
 					TagName:       "3.0.0-alpha2",
-					PublishedDate: "2020-06-29T00:00:00Z",
+					PublishedDate: time.Date(2020, 06, 29, 0, 0, 0, 0, time.UTC),
 				},
 				{
 					TagName:       "3.0.0-alpha1",
-					PublishedDate: "2020-06-29T00:00:00Z",
+					PublishedDate: time.Date(2020, 06, 29, 0, 0, 0, 0, time.UTC),
 				},
 				{
 					TagName:       "1.0.1",
-					PublishedDate: "2020-06-29T00:00:00Z",
+					PublishedDate: time.Date(2020, 06, 29, 0, 0, 0, 0, time.UTC),
 				},
 				{
 					TagName:       "2.0.0",
-					PublishedDate: "2020-06-28T00:00:00Z",
+					PublishedDate: time.Date(2020, 06, 28, 0, 0, 0, 0, time.UTC),
 				},
 				{
 					TagName:       "1.0.0",
-					PublishedDate: "2020-06-27T00:00:00Z",
+					PublishedDate: time.Date(2020, 06, 27, 0, 0, 0, 0, time.UTC),
 				},
 			}, nil)
 
@@ -90,15 +91,15 @@ func testComposer(t *testing.T, when spec.G, it spec.S) {
 			fakeGithubClient.GetReleaseTagsReturns([]internal.GithubRelease{
 				{
 					TagName:       "3.0.0",
-					PublishedDate: "2020-06-30T00:00:00Z",
+					PublishedDate: time.Date(2020, 06, 30, 0, 0, 0, 0, time.UTC),
 				},
 				{
 					TagName:       "1.0.1",
-					PublishedDate: "2020-06-29T00:00:00Z",
+					PublishedDate: time.Date(2020, 06, 29, 0, 0, 0, 0, time.UTC),
 				},
 				{
 					TagName:       "2.0.0",
-					PublishedDate: "2020-06-28T00:00:00Z",
+					PublishedDate: time.Date(2020, 06, 28, 0, 0, 0, 0, time.UTC),
 				},
 			}, nil)
 			fakeWebClient.GetReturnsOnCall(0,
@@ -107,12 +108,13 @@ func testComposer(t *testing.T, when spec.G, it spec.S) {
 			actualDep, err := composer.GetDependencyVersion("1.0.1")
 			require.NoError(err)
 
+			expectedReleaseDate := time.Date(2020, 6, 29, 0, 0, 0, 0, time.UTC)
 			expectedDep := dependency.DepVersion{
 				Version:         "1.0.1",
 				URI:             "https://getcomposer.org/download/1.0.1/composer.phar",
 				SHA:             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-				ReleaseDate:     "2020-06-29T00:00:00Z",
-				DeprecationDate: "",
+				ReleaseDate:     &expectedReleaseDate,
+				DeprecationDate: nil,
 			}
 			assert.Equal(expectedDep, actualDep)
 
@@ -126,7 +128,7 @@ func testComposer(t *testing.T, when spec.G, it spec.S) {
 				fakeGithubClient.GetReleaseTagsReturns([]internal.GithubRelease{
 					{
 						TagName:       "3.0.0",
-						PublishedDate: "2020-06-30T00:00:00Z",
+						PublishedDate: time.Date(2020, 06, 30, 0, 0, 0, 0, time.UTC),
 					},
 				}, nil)
 				fakeWebClient.GetReturnsOnCall(0, nil, nil)
@@ -144,15 +146,15 @@ func testComposer(t *testing.T, when spec.G, it spec.S) {
 			fakeGithubClient.GetReleaseTagsReturns([]internal.GithubRelease{
 				{
 					TagName:       "3.0.0",
-					PublishedDate: "2020-06-30T00:00:00Z",
+					PublishedDate: time.Date(2020, 06, 30, 0, 0, 0, 0, time.UTC),
 				},
 				{
 					TagName:       "1.0.1",
-					PublishedDate: "2020-06-29T00:00:00Z",
+					PublishedDate: time.Date(2020, 06, 29, 0, 0, 0, 0, time.UTC),
 				},
 				{
 					TagName:       "2.0.0",
-					PublishedDate: "2020-06-28T00:00:00Z",
+					PublishedDate: time.Date(2020, 06, 28, 0, 0, 0, 0, time.UTC),
 				},
 			}, nil)
 

--- a/pkg/dependency/curl.go
+++ b/pkg/dependency/curl.go
@@ -127,7 +127,7 @@ func (c Curl) createDependencyVersion(release CurlRelease) (DepVersion, error) {
 	return DepVersion{
 		Version:     release.Version,
 		URI:         c.dependencyURL(release),
-		SHA:         sha,
+		SHA256:      sha,
 		ReleaseDate: &release.Date,
 		CPE:         fmt.Sprintf("cpe:2.3:a:haxx:curl:%s:*:*:*:*:*:*:*", release.Version),
 	}, nil

--- a/pkg/dependency/curl.go
+++ b/pkg/dependency/curl.go
@@ -61,19 +61,19 @@ func (c Curl) GetDependencyVersion(version string) (DepVersion, error) {
 	return DepVersion{}, fmt.Errorf("could not find version %s", version)
 }
 
-func (c Curl) GetReleaseDate(version string) (time.Time, error) {
+func (c Curl) GetReleaseDate(version string) (*time.Time, error) {
 	curlReleases, err := c.getAllReleases()
 	if err != nil {
-		return time.Time{}, fmt.Errorf("could not get releases: %w", err)
+		return nil, fmt.Errorf("could not get releases: %w", err)
 	}
 
 	for _, release := range curlReleases {
 		if release.Version == version {
-			return release.Date, nil
+			return &release.Date, nil
 		}
 	}
 
-	return time.Time{}, fmt.Errorf("could not find release date for version %s", version)
+	return nil, fmt.Errorf("could not find release date for version %s", version)
 }
 
 func (c Curl) getAllReleases() ([]CurlRelease, error) {
@@ -128,7 +128,7 @@ func (c Curl) createDependencyVersion(release CurlRelease) (DepVersion, error) {
 		Version:     release.Version,
 		URI:         c.dependencyURL(release),
 		SHA:         sha,
-		ReleaseDate: release.Date.Format(time.RFC3339),
+		ReleaseDate: &release.Date,
 		CPE:         fmt.Sprintf("cpe:2.3:a:haxx:curl:%s:*:*:*:*:*:*:*", release.Version),
 	}, nil
 }

--- a/pkg/dependency/curl_test.go
+++ b/pkg/dependency/curl_test.go
@@ -77,7 +77,7 @@ func testCurl(t *testing.T, when spec.G, it spec.S) {
 			expectedDep := dependency.DepVersion{
 				Version:     "7.73.0",
 				URI:         "https://curl.se/download/curl-7.73.0.tar.gz",
-				SHA:         "some-source-sha",
+				SHA256:      "some-source-sha",
 				ReleaseDate: &expectedReleaseDate,
 				CPE:         "cpe:2.3:a:haxx:curl:7.73.0:*:*:*:*:*:*:*",
 			}
@@ -118,7 +118,7 @@ func testCurl(t *testing.T, when spec.G, it spec.S) {
 				expectedDep := dependency.DepVersion{
 					Version:     "7.29.0",
 					URI:         "https://curl.se/download/archeology/curl-7.29.0.tar.gz",
-					SHA:         "some-source-sha",
+					SHA256:      "some-source-sha",
 					ReleaseDate: &expectedReleaseDate,
 					CPE:         "cpe:2.3:a:haxx:curl:7.29.0:*:*:*:*:*:*:*",
 				}

--- a/pkg/dependency/curl_test.go
+++ b/pkg/dependency/curl_test.go
@@ -73,11 +73,12 @@ func testCurl(t *testing.T, when spec.G, it spec.S) {
 			actualDep, err := curl.GetDependencyVersion("7.73.0")
 			require.NoError(err)
 
+			expectedReleaseDate := time.Date(2020, 10, 14, 0, 0, 0, 0, time.UTC)
 			expectedDep := dependency.DepVersion{
 				Version:     "7.73.0",
 				URI:         "https://curl.se/download/curl-7.73.0.tar.gz",
 				SHA:         "some-source-sha",
-				ReleaseDate: "2020-10-14T00:00:00Z",
+				ReleaseDate: &expectedReleaseDate,
 				CPE:         "cpe:2.3:a:haxx:curl:7.73.0:*:*:*:*:*:*:*",
 			}
 
@@ -113,11 +114,12 @@ func testCurl(t *testing.T, when spec.G, it spec.S) {
 				actualDep, err := curl.GetDependencyVersion("7.29.0")
 				require.NoError(err)
 
+				expectedReleaseDate := time.Date(2013, 02, 06, 0, 0, 0, 0, time.UTC)
 				expectedDep := dependency.DepVersion{
 					Version:     "7.29.0",
 					URI:         "https://curl.se/download/archeology/curl-7.29.0.tar.gz",
 					SHA:         "some-source-sha",
-					ReleaseDate: "2013-02-06T00:00:00Z",
+					ReleaseDate: &expectedReleaseDate,
 					CPE:         "cpe:2.3:a:haxx:curl:7.29.0:*:*:*:*:*:*:*",
 				}
 

--- a/pkg/dependency/dep_factory.go
+++ b/pkg/dependency/dep_factory.go
@@ -2,23 +2,24 @@ package dependency
 
 import (
 	"fmt"
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency/internal"
 	"time"
+
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency/internal"
 )
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 . Dependency
 type Dependency interface {
 	GetAllVersionRefs() ([]string, error)
 	GetDependencyVersion(version string) (DepVersion, error)
-	GetReleaseDate(version string) (time.Time, error)
+	GetReleaseDate(version string) (*time.Time, error)
 }
 
 type DepVersion struct {
 	Version         string `json:"version"`
 	URI             string `json:"uri"`
 	SHA             string `json:"sha"`
-	ReleaseDate     string `json:"release_date"`
-	DeprecationDate string `json:"deprecation_date"`
+	ReleaseDate     *time.Time `json:"release_date,omitempty"`
+	DeprecationDate *time.Time `json:"deprecation_date,omitempty"`
 	CPE             string `json:"cpe"`
 }
 

--- a/pkg/dependency/dep_factory.go
+++ b/pkg/dependency/dep_factory.go
@@ -15,12 +15,12 @@ type Dependency interface {
 }
 
 type DepVersion struct {
-	Version         string `json:"version"`
-	URI             string `json:"uri"`
-	SHA             string `json:"sha"`
+	Version         string     `json:"version"`
+	URI             string     `json:"uri"`
+	SHA256          string     `json:"sha256"`
 	ReleaseDate     *time.Time `json:"release_date,omitempty"`
 	DeprecationDate *time.Time `json:"deprecation_date,omitempty"`
-	CPE             string `json:"cpe"`
+	CPE             string     `json:"cpe"`
 }
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 . Checksummer

--- a/pkg/dependency/dependencyfakes/fake_dependency.go
+++ b/pkg/dependency/dependencyfakes/fake_dependency.go
@@ -34,17 +34,17 @@ type FakeDependency struct {
 		result1 dependency.DepVersion
 		result2 error
 	}
-	GetReleaseDateStub        func(string) (time.Time, error)
+	GetReleaseDateStub        func(string) (*time.Time, error)
 	getReleaseDateMutex       sync.RWMutex
 	getReleaseDateArgsForCall []struct {
 		arg1 string
 	}
 	getReleaseDateReturns struct {
-		result1 time.Time
+		result1 *time.Time
 		result2 error
 	}
 	getReleaseDateReturnsOnCall map[int]struct {
-		result1 time.Time
+		result1 *time.Time
 		result2 error
 	}
 	invocations      map[string][][]interface{}
@@ -171,7 +171,7 @@ func (fake *FakeDependency) GetDependencyVersionReturnsOnCall(i int, result1 dep
 	}{result1, result2}
 }
 
-func (fake *FakeDependency) GetReleaseDate(arg1 string) (time.Time, error) {
+func (fake *FakeDependency) GetReleaseDate(arg1 string) (*time.Time, error) {
 	fake.getReleaseDateMutex.Lock()
 	ret, specificReturn := fake.getReleaseDateReturnsOnCall[len(fake.getReleaseDateArgsForCall)]
 	fake.getReleaseDateArgsForCall = append(fake.getReleaseDateArgsForCall, struct {
@@ -196,7 +196,7 @@ func (fake *FakeDependency) GetReleaseDateCallCount() int {
 	return len(fake.getReleaseDateArgsForCall)
 }
 
-func (fake *FakeDependency) GetReleaseDateCalls(stub func(string) (time.Time, error)) {
+func (fake *FakeDependency) GetReleaseDateCalls(stub func(string) (*time.Time, error)) {
 	fake.getReleaseDateMutex.Lock()
 	defer fake.getReleaseDateMutex.Unlock()
 	fake.GetReleaseDateStub = stub
@@ -209,28 +209,28 @@ func (fake *FakeDependency) GetReleaseDateArgsForCall(i int) string {
 	return argsForCall.arg1
 }
 
-func (fake *FakeDependency) GetReleaseDateReturns(result1 time.Time, result2 error) {
+func (fake *FakeDependency) GetReleaseDateReturns(result1 *time.Time, result2 error) {
 	fake.getReleaseDateMutex.Lock()
 	defer fake.getReleaseDateMutex.Unlock()
 	fake.GetReleaseDateStub = nil
 	fake.getReleaseDateReturns = struct {
-		result1 time.Time
+		result1 *time.Time
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeDependency) GetReleaseDateReturnsOnCall(i int, result1 time.Time, result2 error) {
+func (fake *FakeDependency) GetReleaseDateReturnsOnCall(i int, result1 *time.Time, result2 error) {
 	fake.getReleaseDateMutex.Lock()
 	defer fake.getReleaseDateMutex.Unlock()
 	fake.GetReleaseDateStub = nil
 	if fake.getReleaseDateReturnsOnCall == nil {
 		fake.getReleaseDateReturnsOnCall = make(map[int]struct {
-			result1 time.Time
+			result1 *time.Time
 			result2 error
 		})
 	}
 	fake.getReleaseDateReturnsOnCall[i] = struct {
-		result1 time.Time
+		result1 *time.Time
 		result2 error
 	}{result1, result2}
 }

--- a/pkg/dependency/dotnet.go
+++ b/pkg/dependency/dotnet.go
@@ -3,14 +3,16 @@ package dependency
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/Masterminds/semver"
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency/errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/Masterminds/semver"
+
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency/errors"
 )
 
 const (
@@ -124,7 +126,7 @@ func (d dotnet) GetDependencyVersion(version string) (DepVersion, error) {
 	depVersion := DepVersion{
 		Version:     version,
 		URI:         releaseFile.URL,
-		SHA:         sha256,
+		SHA256:      sha256,
 		ReleaseDate: releaseDate,
 		CPE:         cpe,
 	}

--- a/pkg/dependency/dotnet_aspnetcore.go
+++ b/pkg/dependency/dotnet_aspnetcore.go
@@ -29,7 +29,7 @@ func (d DotnetASPNETCore) GetDependencyVersion(version string) (DepVersion, erro
 	}.GetDependencyVersion(version)
 }
 
-func (d DotnetASPNETCore) GetReleaseDate(version string) (time.Time, error) {
+func (d DotnetASPNETCore) GetReleaseDate(version string) (*time.Time, error) {
 	return dotnet{
 		dotnetType:  dotnetASPNETCoreType{},
 		checksummer: d.checksummer,
@@ -41,13 +41,17 @@ func (d dotnetASPNETCoreType) getChannelVersion(version string) string {
 	return strings.Join(strings.Split(version, ".")[0:2], ".")
 }
 
-func (d dotnetASPNETCoreType) getReleaseDate(channel DotnetChannel, version string) string {
+func (d dotnetASPNETCoreType) getReleaseDate(channel DotnetChannel, version string) (*time.Time, error) {
 	for _, release := range channel.Releases {
 		if release.ASPNETCoreRuntime.Version == version {
-			return release.ReleaseDate
+			releaseDate, err := time.Parse("2006-01-02", release.ReleaseDate)
+			if err != nil {
+				return nil, fmt.Errorf("could not parse release date: %w", err)
+			}
+			return &releaseDate, nil
 		}
 	}
-	return ""
+	return nil, nil
 }
 
 func (d dotnetASPNETCoreType) getReleaseFiles(channel DotnetChannel, version string) []DotnetChannelReleaseFile {

--- a/pkg/dependency/dotnet_aspnetcore_test.go
+++ b/pkg/dependency/dotnet_aspnetcore_test.go
@@ -2,15 +2,17 @@ package dependency_test
 
 import (
 	"errors"
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency"
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency/dependencyfakes"
-	depErrors "github.com/paketo-buildpacks/dep-server/pkg/dependency/errors"
+	"testing"
+	"time"
+
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
-	"time"
+
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency"
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency/dependencyfakes"
+	depErrors "github.com/paketo-buildpacks/dep-server/pkg/dependency/errors"
 )
 
 func TestDotnetASPNETCore(t *testing.T) {
@@ -185,7 +187,7 @@ func testDotnetASPNETCore(t *testing.T, when spec.G, it spec.S) {
 
 	when("GetDependencyVersion", func() {
 		var (
-			expectedReleaseDate = time.Date(2020, 02, 20, 0, 0, 0, 0, time.UTC)
+			expectedReleaseDate     = time.Date(2020, 02, 20, 0, 0, 0, 0, time.UTC)
 			expectedDeprecationDate = time.Date(2050, 02, 20, 0, 0, 0, 0, time.UTC)
 		)
 
@@ -259,7 +261,7 @@ func testDotnetASPNETCore(t *testing.T, when spec.G, it spec.S) {
 			expectedDep := dependency.DepVersion{
 				Version:         "2.0.1",
 				URI:             "url-for-linux-x64-2.0.1",
-				SHA:             "some-sha256",
+				SHA256:          "some-sha256",
 				ReleaseDate:     &expectedReleaseDate,
 				DeprecationDate: &expectedDeprecationDate,
 				CPE:             "cpe:2.3:a:microsoft:asp.net_core:2.0:*:*:*:*:*:*:*",
@@ -319,7 +321,7 @@ func testDotnetASPNETCore(t *testing.T, when spec.G, it spec.S) {
 				expectedDep := dependency.DepVersion{
 					Version:         "2.0.1",
 					URI:             "url-for-ubuntu-x64-2.0.1",
-					SHA:             "some-sha256",
+					SHA256:          "some-sha256",
 					ReleaseDate:     &expectedReleaseDate,
 					DeprecationDate: &expectedDeprecationDate,
 					CPE:             "cpe:2.3:a:microsoft:asp.net_core:2.0:*:*:*:*:*:*:*",
@@ -406,7 +408,7 @@ func testDotnetASPNETCore(t *testing.T, when spec.G, it spec.S) {
 				expectedDep := dependency.DepVersion{
 					Version:         "2.0.1",
 					URI:             "url-for-linux-x64-2.0.1",
-					SHA:             "some-sha256",
+					SHA256:          "some-sha256",
 					ReleaseDate:     &expectedReleaseDate,
 					DeprecationDate: &expectedDeprecationDate,
 					CPE:             "cpe:2.3:a:microsoft:asp.net_core:2.0:*:*:*:*:*:*:*",
@@ -447,7 +449,7 @@ func testDotnetASPNETCore(t *testing.T, when spec.G, it spec.S) {
 				expectedDep := dependency.DepVersion{
 					Version:         "2.0.1",
 					URI:             "url-for-linux-x64-2.0.1",
-					SHA:             "shaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa256",
+					SHA256:          "shaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa256",
 					ReleaseDate:     &expectedReleaseDate,
 					DeprecationDate: &expectedDeprecationDate,
 					CPE:             "cpe:2.3:a:microsoft:asp.net_core:2.0:*:*:*:*:*:*:*",
@@ -491,7 +493,7 @@ func testDotnetASPNETCore(t *testing.T, when spec.G, it spec.S) {
 				expectedDep := dependency.DepVersion{
 					Version:         "2.0.2",
 					URI:             "url-for-linux-x64-2.0.2",
-					SHA:             "some-sha256",
+					SHA256:          "some-sha256",
 					ReleaseDate:     &expectedReleaseDate,
 					DeprecationDate: nil,
 					CPE:             "cpe:2.3:a:microsoft:asp.net_core:2.0:*:*:*:*:*:*:*",

--- a/pkg/dependency/dotnet_aspnetcore_test.go
+++ b/pkg/dependency/dotnet_aspnetcore_test.go
@@ -184,6 +184,11 @@ func testDotnetASPNETCore(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	when("GetDependencyVersion", func() {
+		var (
+			expectedReleaseDate = time.Date(2020, 02, 20, 0, 0, 0, 0, time.UTC)
+			expectedDeprecationDate = time.Date(2050, 02, 20, 0, 0, 0, 0, time.UTC)
+		)
+
 		it("returns the correct dotnet aspnetcore version", func() {
 			fakeWebClient.GetReturns([]byte(`
 {
@@ -255,8 +260,8 @@ func testDotnetASPNETCore(t *testing.T, when spec.G, it spec.S) {
 				Version:         "2.0.1",
 				URI:             "url-for-linux-x64-2.0.1",
 				SHA:             "some-sha256",
-				ReleaseDate:     "2020-02-20T00:00:00Z",
-				DeprecationDate: "2050-02-20T00:00:00Z",
+				ReleaseDate:     &expectedReleaseDate,
+				DeprecationDate: &expectedDeprecationDate,
 				CPE:             "cpe:2.3:a:microsoft:asp.net_core:2.0:*:*:*:*:*:*:*",
 			}
 			assert.Equal(expectedDep, actualDep)
@@ -315,8 +320,8 @@ func testDotnetASPNETCore(t *testing.T, when spec.G, it spec.S) {
 					Version:         "2.0.1",
 					URI:             "url-for-ubuntu-x64-2.0.1",
 					SHA:             "some-sha256",
-					ReleaseDate:     "2020-02-20T00:00:00Z",
-					DeprecationDate: "2050-02-20T00:00:00Z",
+					ReleaseDate:     &expectedReleaseDate,
+					DeprecationDate: &expectedDeprecationDate,
 					CPE:             "cpe:2.3:a:microsoft:asp.net_core:2.0:*:*:*:*:*:*:*",
 				}
 				assert.Equal(expectedDep, actualDep)
@@ -402,8 +407,8 @@ func testDotnetASPNETCore(t *testing.T, when spec.G, it spec.S) {
 					Version:         "2.0.1",
 					URI:             "url-for-linux-x64-2.0.1",
 					SHA:             "some-sha256",
-					ReleaseDate:     "2020-02-20T00:00:00Z",
-					DeprecationDate: "2050-02-20T00:00:00Z",
+					ReleaseDate:     &expectedReleaseDate,
+					DeprecationDate: &expectedDeprecationDate,
 					CPE:             "cpe:2.3:a:microsoft:asp.net_core:2.0:*:*:*:*:*:*:*",
 				}
 				assert.Equal(expectedDep, actualDep)
@@ -443,8 +448,8 @@ func testDotnetASPNETCore(t *testing.T, when spec.G, it spec.S) {
 					Version:         "2.0.1",
 					URI:             "url-for-linux-x64-2.0.1",
 					SHA:             "shaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa256",
-					ReleaseDate:     "2020-02-20T00:00:00Z",
-					DeprecationDate: "2050-02-20T00:00:00Z",
+					ReleaseDate:     &expectedReleaseDate,
+					DeprecationDate: &expectedDeprecationDate,
 					CPE:             "cpe:2.3:a:microsoft:asp.net_core:2.0:*:*:*:*:*:*:*",
 				}
 				assert.Equal(expectedDep, actualDep)
@@ -487,8 +492,8 @@ func testDotnetASPNETCore(t *testing.T, when spec.G, it spec.S) {
 					Version:         "2.0.2",
 					URI:             "url-for-linux-x64-2.0.2",
 					SHA:             "some-sha256",
-					ReleaseDate:     "2020-02-20T00:00:00Z",
-					DeprecationDate: "",
+					ReleaseDate:     &expectedReleaseDate,
+					DeprecationDate: nil,
 					CPE:             "cpe:2.3:a:microsoft:asp.net_core:2.0:*:*:*:*:*:*:*",
 				}
 				assert.Equal(expectedDep, actualDep)

--- a/pkg/dependency/dotnet_runtime.go
+++ b/pkg/dependency/dotnet_runtime.go
@@ -30,7 +30,7 @@ func (d DotnetRuntime) GetDependencyVersion(version string) (DepVersion, error) 
 	}.GetDependencyVersion(version)
 }
 
-func (d DotnetRuntime) GetReleaseDate(version string) (time.Time, error) {
+func (d DotnetRuntime) GetReleaseDate(version string) (*time.Time, error) {
 	return dotnet{
 		dotnetType:  dotnetRuntimeType{},
 		checksummer: d.checksummer,
@@ -42,13 +42,17 @@ func (d dotnetRuntimeType) getChannelVersion(version string) string {
 	return strings.Join(strings.Split(version, ".")[0:2], ".")
 }
 
-func (d dotnetRuntimeType) getReleaseDate(channel DotnetChannel, version string) string {
+func (d dotnetRuntimeType) getReleaseDate(channel DotnetChannel, version string) (*time.Time, error) {
 	for _, release := range channel.Releases {
 		if release.Runtime.Version == version {
-			return release.ReleaseDate
+			releaseDate, err := time.Parse("2006-01-02", release.ReleaseDate)
+			if err != nil {
+				return nil, fmt.Errorf("could not parse release date: %w", err)
+			}
+			return &releaseDate, nil
 		}
 	}
-	return ""
+	return nil, nil
 }
 
 func (d dotnetRuntimeType) getReleaseFiles(channel DotnetChannel, version string) []DotnetChannelReleaseFile {

--- a/pkg/dependency/dotnet_runtime_test.go
+++ b/pkg/dependency/dotnet_runtime_test.go
@@ -184,6 +184,11 @@ func testDotnetRuntime(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	when("GetDependencyVersion", func() {
+		var (
+			expectedReleaseDate = time.Date(2020, 02, 20, 0, 0, 0, 0, time.UTC)
+			expectedDeprecationDate = time.Date(2050, 02, 20, 0, 0, 0, 0, time.UTC)
+		)
+
 		it("returns the correct dotnet runtime version", func() {
 			fakeWebClient.GetReturns([]byte(`
 {
@@ -255,8 +260,8 @@ func testDotnetRuntime(t *testing.T, when spec.G, it spec.S) {
 				Version:         "2.0.1",
 				URI:             "url-for-linux-x64-2.0.1",
 				SHA:             "some-sha256",
-				ReleaseDate:     "2020-02-20T00:00:00Z",
-				DeprecationDate: "2050-02-20T00:00:00Z",
+				ReleaseDate:     &expectedReleaseDate,
+				DeprecationDate: &expectedDeprecationDate,
 				CPE:             "cpe:2.3:a:microsoft:.net_core:2.0.1:*:*:*:*:*:*:*",
 			}
 			assert.Equal(expectedDep, actualDep)
@@ -343,8 +348,8 @@ func testDotnetRuntime(t *testing.T, when spec.G, it spec.S) {
 					Version:         "5.0.1",
 					URI:             "url-for-linux-x64-5.0.1",
 					SHA:             "some-sha256",
-					ReleaseDate:     "2020-02-20T00:00:00Z",
-					DeprecationDate: "2050-02-20T00:00:00Z",
+					ReleaseDate:     &expectedReleaseDate,
+					DeprecationDate: &expectedDeprecationDate,
 					CPE:             "cpe:2.3:a:microsoft:.net:5.0.1:*:*:*:*:*:*:*",
 				}
 				assert.Equal(expectedDep, actualDep)
@@ -404,8 +409,8 @@ func testDotnetRuntime(t *testing.T, when spec.G, it spec.S) {
 					Version:         "2.0.1",
 					URI:             "url-for-ubuntu-x64-2.0.1",
 					SHA:             "some-sha256",
-					ReleaseDate:     "2020-02-20T00:00:00Z",
-					DeprecationDate: "2050-02-20T00:00:00Z",
+					ReleaseDate:     &expectedReleaseDate,
+					DeprecationDate: &expectedDeprecationDate,
 					CPE:             "cpe:2.3:a:microsoft:.net_core:2.0.1:*:*:*:*:*:*:*",
 				}
 				assert.Equal(expectedDep, actualDep)
@@ -491,8 +496,8 @@ func testDotnetRuntime(t *testing.T, when spec.G, it spec.S) {
 					Version:         "2.0.1",
 					URI:             "url-for-linux-x64-2.0.1",
 					SHA:             "some-sha256",
-					ReleaseDate:     "2020-02-20T00:00:00Z",
-					DeprecationDate: "2050-02-20T00:00:00Z",
+					ReleaseDate:     &expectedReleaseDate,
+					DeprecationDate: &expectedDeprecationDate,
 					CPE:             "cpe:2.3:a:microsoft:.net_core:2.0.1:*:*:*:*:*:*:*",
 				}
 				assert.Equal(expectedDep, actualDep)
@@ -532,8 +537,8 @@ func testDotnetRuntime(t *testing.T, when spec.G, it spec.S) {
 					Version:         "2.0.1",
 					URI:             "url-for-linux-x64-2.0.1",
 					SHA:             "shaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa256",
-					ReleaseDate:     "2020-02-20T00:00:00Z",
-					DeprecationDate: "2050-02-20T00:00:00Z",
+					ReleaseDate:     &expectedReleaseDate,
+					DeprecationDate: &expectedDeprecationDate,
 					CPE:             "cpe:2.3:a:microsoft:.net_core:2.0.1:*:*:*:*:*:*:*",
 				}
 				assert.Equal(expectedDep, actualDep)
@@ -576,8 +581,8 @@ func testDotnetRuntime(t *testing.T, when spec.G, it spec.S) {
 					Version:         "2.0.2",
 					URI:             "url-for-linux-x64-2.0.2",
 					SHA:             "some-sha256",
-					ReleaseDate:     "2020-02-20T00:00:00Z",
-					DeprecationDate: "",
+					ReleaseDate:     &expectedReleaseDate,
+					DeprecationDate: nil,
 					CPE:             "cpe:2.3:a:microsoft:.net_core:2.0.2:*:*:*:*:*:*:*",
 				}
 				assert.Equal(expectedDep, actualDep)

--- a/pkg/dependency/dotnet_runtime_test.go
+++ b/pkg/dependency/dotnet_runtime_test.go
@@ -2,15 +2,17 @@ package dependency_test
 
 import (
 	"errors"
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency"
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency/dependencyfakes"
-	depErrors "github.com/paketo-buildpacks/dep-server/pkg/dependency/errors"
+	"testing"
+	"time"
+
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
-	"time"
+
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency"
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency/dependencyfakes"
+	depErrors "github.com/paketo-buildpacks/dep-server/pkg/dependency/errors"
 )
 
 func TestDotnetRuntime(t *testing.T) {
@@ -185,7 +187,7 @@ func testDotnetRuntime(t *testing.T, when spec.G, it spec.S) {
 
 	when("GetDependencyVersion", func() {
 		var (
-			expectedReleaseDate = time.Date(2020, 02, 20, 0, 0, 0, 0, time.UTC)
+			expectedReleaseDate     = time.Date(2020, 02, 20, 0, 0, 0, 0, time.UTC)
 			expectedDeprecationDate = time.Date(2050, 02, 20, 0, 0, 0, 0, time.UTC)
 		)
 
@@ -259,7 +261,7 @@ func testDotnetRuntime(t *testing.T, when spec.G, it spec.S) {
 			expectedDep := dependency.DepVersion{
 				Version:         "2.0.1",
 				URI:             "url-for-linux-x64-2.0.1",
-				SHA:             "some-sha256",
+				SHA256:          "some-sha256",
 				ReleaseDate:     &expectedReleaseDate,
 				DeprecationDate: &expectedDeprecationDate,
 				CPE:             "cpe:2.3:a:microsoft:.net_core:2.0.1:*:*:*:*:*:*:*",
@@ -347,7 +349,7 @@ func testDotnetRuntime(t *testing.T, when spec.G, it spec.S) {
 				expectedDep := dependency.DepVersion{
 					Version:         "5.0.1",
 					URI:             "url-for-linux-x64-5.0.1",
-					SHA:             "some-sha256",
+					SHA256:          "some-sha256",
 					ReleaseDate:     &expectedReleaseDate,
 					DeprecationDate: &expectedDeprecationDate,
 					CPE:             "cpe:2.3:a:microsoft:.net:5.0.1:*:*:*:*:*:*:*",
@@ -408,7 +410,7 @@ func testDotnetRuntime(t *testing.T, when spec.G, it spec.S) {
 				expectedDep := dependency.DepVersion{
 					Version:         "2.0.1",
 					URI:             "url-for-ubuntu-x64-2.0.1",
-					SHA:             "some-sha256",
+					SHA256:          "some-sha256",
 					ReleaseDate:     &expectedReleaseDate,
 					DeprecationDate: &expectedDeprecationDate,
 					CPE:             "cpe:2.3:a:microsoft:.net_core:2.0.1:*:*:*:*:*:*:*",
@@ -495,7 +497,7 @@ func testDotnetRuntime(t *testing.T, when spec.G, it spec.S) {
 				expectedDep := dependency.DepVersion{
 					Version:         "2.0.1",
 					URI:             "url-for-linux-x64-2.0.1",
-					SHA:             "some-sha256",
+					SHA256:          "some-sha256",
 					ReleaseDate:     &expectedReleaseDate,
 					DeprecationDate: &expectedDeprecationDate,
 					CPE:             "cpe:2.3:a:microsoft:.net_core:2.0.1:*:*:*:*:*:*:*",
@@ -536,7 +538,7 @@ func testDotnetRuntime(t *testing.T, when spec.G, it spec.S) {
 				expectedDep := dependency.DepVersion{
 					Version:         "2.0.1",
 					URI:             "url-for-linux-x64-2.0.1",
-					SHA:             "shaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa256",
+					SHA256:          "shaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa256",
 					ReleaseDate:     &expectedReleaseDate,
 					DeprecationDate: &expectedDeprecationDate,
 					CPE:             "cpe:2.3:a:microsoft:.net_core:2.0.1:*:*:*:*:*:*:*",
@@ -580,7 +582,7 @@ func testDotnetRuntime(t *testing.T, when spec.G, it spec.S) {
 				expectedDep := dependency.DepVersion{
 					Version:         "2.0.2",
 					URI:             "url-for-linux-x64-2.0.2",
-					SHA:             "some-sha256",
+					SHA256:          "some-sha256",
 					ReleaseDate:     &expectedReleaseDate,
 					DeprecationDate: nil,
 					CPE:             "cpe:2.3:a:microsoft:.net_core:2.0.2:*:*:*:*:*:*:*",

--- a/pkg/dependency/dotnet_sdk.go
+++ b/pkg/dependency/dotnet_sdk.go
@@ -30,7 +30,7 @@ func (d DotnetSDK) GetDependencyVersion(version string) (DepVersion, error) {
 	}.GetDependencyVersion(version)
 }
 
-func (d DotnetSDK) GetReleaseDate(version string) (time.Time, error) {
+func (d DotnetSDK) GetReleaseDate(version string) (*time.Time, error) {
 	return dotnet{
 		dotnetType:  dotnetSDKType{},
 		checksummer: d.checksummer,
@@ -53,19 +53,27 @@ func (d dotnetSDKType) getReleaseFiles(channel DotnetChannel, version string) []
 	return nil
 }
 
-func (d dotnetSDKType) getReleaseDate(channel DotnetChannel, version string) string {
+func (d dotnetSDKType) getReleaseDate(channel DotnetChannel, version string) (*time.Time, error) {
 	for _, release := range channel.Releases {
 		if release.SDK.Version == version {
-			return release.ReleaseDate
+			releaseDate, err := time.Parse("2006-01-02", release.ReleaseDate)
+			if err != nil {
+				return nil, fmt.Errorf("could not parse release date: %w", err)
+			}
+			return &releaseDate, nil
 		}
 
 		for _, sdk := range release.SDKs {
 			if sdk.Version == version {
-				return release.ReleaseDate
+				releaseDate, err := time.Parse("2006-01-02", release.ReleaseDate)
+				if err != nil {
+					return nil, fmt.Errorf("could not parse release date: %w", err)
+				}
+				return &releaseDate, nil
 			}
 		}
 	}
-	return ""
+	return nil, nil
 }
 
 func (d dotnetSDKType) getReleaseVersions(release DotnetChannelRelease) []string {

--- a/pkg/dependency/dotnet_sdk_test.go
+++ b/pkg/dependency/dotnet_sdk_test.go
@@ -229,6 +229,11 @@ func testDotnetSDK(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	when("GetDependencyVersion", func() {
+		var(
+			expectedReleaseDate = time.Date(2020, 02, 20, 0, 0, 0, 0, time.UTC)
+			expectedDeprecationDate = time.Date(2050, 02, 20, 0, 0, 0, 0, time.UTC)
+		)
+
 		it("returns the correct dotnet SDK version", func() {
 			fakeWebClient.GetReturns([]byte(`
 {
@@ -321,8 +326,8 @@ func testDotnetSDK(t *testing.T, when spec.G, it spec.S) {
 				Version:         "2.0.201",
 				URI:             "url-for-linux-x64-2.0.201",
 				SHA:             "some-sha256",
-				ReleaseDate:     "2020-02-20T00:00:00Z",
-				DeprecationDate: "2050-02-20T00:00:00Z",
+				ReleaseDate:     &expectedReleaseDate,
+				DeprecationDate: &expectedDeprecationDate,
 				CPE:             "cpe:2.3:a:microsoft:.net_core:2.0.201:*:*:*:*:*:*:*",
 			}
 			assert.Equal(expectedDep, actualDep)
@@ -430,8 +435,8 @@ func testDotnetSDK(t *testing.T, when spec.G, it spec.S) {
 					Version:         "5.0.201",
 					URI:             "url-for-linux-x64-5.0.201",
 					SHA:             "some-sha256",
-					ReleaseDate:     "2020-02-20T00:00:00Z",
-					DeprecationDate: "2050-02-20T00:00:00Z",
+					ReleaseDate:     &expectedReleaseDate,
+					DeprecationDate: &expectedDeprecationDate,
 					CPE:             "cpe:2.3:a:microsoft:.net:5.0.201:*:*:*:*:*:*:*",
 				}
 				assert.Equal(expectedDep, actualDep)
@@ -491,8 +496,8 @@ func testDotnetSDK(t *testing.T, when spec.G, it spec.S) {
 					Version:         "2.0.201",
 					URI:             "url-for-ubuntu-x64-2.0.201",
 					SHA:             "some-sha256",
-					ReleaseDate:     "2020-02-20T00:00:00Z",
-					DeprecationDate: "2050-02-20T00:00:00Z",
+					ReleaseDate:     &expectedReleaseDate,
+					DeprecationDate: &expectedDeprecationDate,
 					CPE:             "cpe:2.3:a:microsoft:.net_core:2.0.201:*:*:*:*:*:*:*",
 				}
 				assert.Equal(expectedDep, actualDep)
@@ -578,8 +583,8 @@ func testDotnetSDK(t *testing.T, when spec.G, it spec.S) {
 					Version:         "2.0.201",
 					URI:             "url-for-linux-x64-2.0.201",
 					SHA:             "some-sha256",
-					ReleaseDate:     "2020-02-20T00:00:00Z",
-					DeprecationDate: "2050-02-20T00:00:00Z",
+					ReleaseDate:     &expectedReleaseDate,
+					DeprecationDate: &expectedDeprecationDate,
 					CPE:             "cpe:2.3:a:microsoft:.net_core:2.0.201:*:*:*:*:*:*:*",
 				}
 				assert.Equal(expectedDep, actualDep)
@@ -619,8 +624,8 @@ func testDotnetSDK(t *testing.T, when spec.G, it spec.S) {
 					Version:         "2.0.201",
 					URI:             "url-for-linux-x64-2.0.201",
 					SHA:             "shaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa256",
-					ReleaseDate:     "2020-02-20T00:00:00Z",
-					DeprecationDate: "2050-02-20T00:00:00Z",
+					ReleaseDate:     &expectedReleaseDate,
+					DeprecationDate: &expectedDeprecationDate,
 					CPE:             "cpe:2.3:a:microsoft:.net_core:2.0.201:*:*:*:*:*:*:*",
 				}
 				assert.Equal(expectedDep, actualDep)
@@ -662,8 +667,8 @@ func testDotnetSDK(t *testing.T, when spec.G, it spec.S) {
 					Version:         "2.1.201",
 					URI:             "url-for-linux-x64-2.1.201",
 					SHA:             "some-sha256",
-					ReleaseDate:     "2020-02-20T00:00:00Z",
-					DeprecationDate: "2050-02-20T00:00:00Z",
+					ReleaseDate:     &expectedReleaseDate,
+					DeprecationDate: &expectedDeprecationDate,
 					CPE:             "cpe:2.3:a:microsoft:.net_core:2.1.201:*:*:*:*:*:*:*",
 				}
 				assert.Equal(expectedDep, actualDep)
@@ -705,8 +710,8 @@ func testDotnetSDK(t *testing.T, when spec.G, it spec.S) {
 					Version:         "2.0.201",
 					URI:             "url-for-linux-x64-2.0.201",
 					SHA:             "some-sha256",
-					ReleaseDate:     "2020-02-20T00:00:00Z",
-					DeprecationDate: "",
+					ReleaseDate:     &expectedReleaseDate,
+					DeprecationDate: nil,
 					CPE:             "cpe:2.3:a:microsoft:.net_core:2.0.201:*:*:*:*:*:*:*",
 				}
 				assert.Equal(expectedDep, actualDep)

--- a/pkg/dependency/dotnet_sdk_test.go
+++ b/pkg/dependency/dotnet_sdk_test.go
@@ -2,15 +2,17 @@ package dependency_test
 
 import (
 	"errors"
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency"
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency/dependencyfakes"
-	depErrors "github.com/paketo-buildpacks/dep-server/pkg/dependency/errors"
+	"testing"
+	"time"
+
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
-	"time"
+
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency"
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency/dependencyfakes"
+	depErrors "github.com/paketo-buildpacks/dep-server/pkg/dependency/errors"
 )
 
 func TestDotnetSDK(t *testing.T) {
@@ -229,8 +231,8 @@ func testDotnetSDK(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	when("GetDependencyVersion", func() {
-		var(
-			expectedReleaseDate = time.Date(2020, 02, 20, 0, 0, 0, 0, time.UTC)
+		var (
+			expectedReleaseDate     = time.Date(2020, 02, 20, 0, 0, 0, 0, time.UTC)
 			expectedDeprecationDate = time.Date(2050, 02, 20, 0, 0, 0, 0, time.UTC)
 		)
 
@@ -325,7 +327,7 @@ func testDotnetSDK(t *testing.T, when spec.G, it spec.S) {
 			expectedDep := dependency.DepVersion{
 				Version:         "2.0.201",
 				URI:             "url-for-linux-x64-2.0.201",
-				SHA:             "some-sha256",
+				SHA256:          "some-sha256",
 				ReleaseDate:     &expectedReleaseDate,
 				DeprecationDate: &expectedDeprecationDate,
 				CPE:             "cpe:2.3:a:microsoft:.net_core:2.0.201:*:*:*:*:*:*:*",
@@ -434,7 +436,7 @@ func testDotnetSDK(t *testing.T, when spec.G, it spec.S) {
 				expectedDep := dependency.DepVersion{
 					Version:         "5.0.201",
 					URI:             "url-for-linux-x64-5.0.201",
-					SHA:             "some-sha256",
+					SHA256:          "some-sha256",
 					ReleaseDate:     &expectedReleaseDate,
 					DeprecationDate: &expectedDeprecationDate,
 					CPE:             "cpe:2.3:a:microsoft:.net:5.0.201:*:*:*:*:*:*:*",
@@ -495,7 +497,7 @@ func testDotnetSDK(t *testing.T, when spec.G, it spec.S) {
 				expectedDep := dependency.DepVersion{
 					Version:         "2.0.201",
 					URI:             "url-for-ubuntu-x64-2.0.201",
-					SHA:             "some-sha256",
+					SHA256:          "some-sha256",
 					ReleaseDate:     &expectedReleaseDate,
 					DeprecationDate: &expectedDeprecationDate,
 					CPE:             "cpe:2.3:a:microsoft:.net_core:2.0.201:*:*:*:*:*:*:*",
@@ -582,7 +584,7 @@ func testDotnetSDK(t *testing.T, when spec.G, it spec.S) {
 				expectedDep := dependency.DepVersion{
 					Version:         "2.0.201",
 					URI:             "url-for-linux-x64-2.0.201",
-					SHA:             "some-sha256",
+					SHA256:          "some-sha256",
 					ReleaseDate:     &expectedReleaseDate,
 					DeprecationDate: &expectedDeprecationDate,
 					CPE:             "cpe:2.3:a:microsoft:.net_core:2.0.201:*:*:*:*:*:*:*",
@@ -623,7 +625,7 @@ func testDotnetSDK(t *testing.T, when spec.G, it spec.S) {
 				expectedDep := dependency.DepVersion{
 					Version:         "2.0.201",
 					URI:             "url-for-linux-x64-2.0.201",
-					SHA:             "shaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa256",
+					SHA256:          "shaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa256",
 					ReleaseDate:     &expectedReleaseDate,
 					DeprecationDate: &expectedDeprecationDate,
 					CPE:             "cpe:2.3:a:microsoft:.net_core:2.0.201:*:*:*:*:*:*:*",
@@ -666,7 +668,7 @@ func testDotnetSDK(t *testing.T, when spec.G, it spec.S) {
 				expectedDep := dependency.DepVersion{
 					Version:         "2.1.201",
 					URI:             "url-for-linux-x64-2.1.201",
-					SHA:             "some-sha256",
+					SHA256:          "some-sha256",
 					ReleaseDate:     &expectedReleaseDate,
 					DeprecationDate: &expectedDeprecationDate,
 					CPE:             "cpe:2.3:a:microsoft:.net_core:2.1.201:*:*:*:*:*:*:*",
@@ -709,7 +711,7 @@ func testDotnetSDK(t *testing.T, when spec.G, it spec.S) {
 				expectedDep := dependency.DepVersion{
 					Version:         "2.0.201",
 					URI:             "url-for-linux-x64-2.0.201",
-					SHA:             "some-sha256",
+					SHA256:          "some-sha256",
 					ReleaseDate:     &expectedReleaseDate,
 					DeprecationDate: nil,
 					CPE:             "cpe:2.3:a:microsoft:.net_core:2.0.201:*:*:*:*:*:*:*",

--- a/pkg/dependency/go.go
+++ b/pkg/dependency/go.go
@@ -3,7 +3,6 @@ package dependency
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency/errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -11,6 +10,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency/errors"
 )
 
 type Go struct {
@@ -65,13 +66,13 @@ func (g Go) GetDependencyVersion(version string) (DepVersion, error) {
 
 	sha, err := g.getDependencySHA(version, goReleasesWithFiles)
 	if err != nil {
-		return DepVersion{}, fmt.Errorf("could not get dependency SHA: %w", err)
+		return DepVersion{}, fmt.Errorf("could not get dependency SHA256: %w", err)
 	}
 
 	return DepVersion{
 		Version:         version,
 		URI:             g.dependencyURL(version),
-		SHA:             sha,
+		SHA256:          sha,
 		ReleaseDate:     releaseDate,
 		DeprecationDate: nil,
 		CPE:             fmt.Sprintf("cpe:2.3:a:golang:go:%s:*:*:*:*:*:*:*", strings.TrimPrefix(version, "go")),
@@ -114,7 +115,7 @@ func (g Go) getDependencySHA(version string, releases []GoReleaseWithFiles) (str
 	}
 
 	if !foundSHA {
-		return "", fmt.Errorf("could not find SHA for %s: %w", version, errors.NoSourceCodeError{Version: version})
+		return "", fmt.Errorf("could not find SHA256 for %s: %w", version, errors.NoSourceCodeError{Version: version})
 	}
 
 	if sha == "" {

--- a/pkg/dependency/go.go
+++ b/pkg/dependency/go.go
@@ -72,31 +72,31 @@ func (g Go) GetDependencyVersion(version string) (DepVersion, error) {
 		Version:         version,
 		URI:             g.dependencyURL(version),
 		SHA:             sha,
-		ReleaseDate:     releaseDate.Format(time.RFC3339),
-		DeprecationDate: "",
+		ReleaseDate:     releaseDate,
+		DeprecationDate: nil,
 		CPE:             fmt.Sprintf("cpe:2.3:a:golang:go:%s:*:*:*:*:*:*:*", strings.TrimPrefix(version, "go")),
 	}, nil
 }
 
-func (g Go) GetReleaseDate(version string) (time.Time, error) {
+func (g Go) GetReleaseDate(version string) (*time.Time, error) {
 	body, err := g.webClient.Get("https://golang.org/doc/devel/release.html")
 	if err != nil {
-		return time.Time{}, fmt.Errorf("could not hit golang.org: %w", err)
+		return nil, fmt.Errorf("could not hit golang.org: %w", err)
 	}
 
 	re := regexp.MustCompile(fmt.Sprintf(`%s\s*\(released\s*(.*?)\)`, version))
 	match := re.FindStringSubmatch(string(body))
 
 	if len(match) < 2 {
-		return time.Time{}, fmt.Errorf("could not find release date")
+		return nil, fmt.Errorf("could not find release date")
 	}
 
 	releaseDate, err := time.Parse("2006/01/02", match[1])
 	if err != nil {
-		return time.Time{}, fmt.Errorf("error parsing release date: %w", err)
+		return nil, fmt.Errorf("error parsing release date: %w", err)
 	}
 
-	return releaseDate, nil
+	return &releaseDate, nil
 }
 
 func (g Go) getDependencySHA(version string, releases []GoReleaseWithFiles) (string, error) {

--- a/pkg/dependency/go_test.go
+++ b/pkg/dependency/go_test.go
@@ -111,6 +111,8 @@ func testGo(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	when("GetDependencyVersion", func() {
+		var expectedReleaseDate = time.Date(2020, 03, 19, 0, 0, 0, 0, time.UTC)
+
 		it("returns the correct go version", func() {
 			fakeWebClient.GetReturnsOnCall(0, []byte(`
 [
@@ -149,8 +151,8 @@ func testGo(t *testing.T, when spec.G, it spec.S) {
 				Version:         "go1.13.9",
 				URI:             "https://dl.google.com/go/go1.13.9.src.tar.gz",
 				SHA:             "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-				ReleaseDate:     "2020-03-19T00:00:00Z",
-				DeprecationDate: "",
+				ReleaseDate:     &expectedReleaseDate,
+				DeprecationDate: nil,
 				CPE:             "cpe:2.3:a:golang:go:1.13.9:*:*:*:*:*:*:*",
 			}
 			assert.Equal(expectedDep, actualDep)
@@ -188,8 +190,8 @@ func testGo(t *testing.T, when spec.G, it spec.S) {
 					Version:         "go1.13.9",
 					URI:             "https://dl.google.com/go/go1.13.9.src.tar.gz",
 					SHA:             "some-source-sha",
-					ReleaseDate:     "2020-03-19T00:00:00Z",
-					DeprecationDate: "",
+					ReleaseDate:     &expectedReleaseDate,
+					DeprecationDate: nil,
 					CPE:             "cpe:2.3:a:golang:go:1.13.9:*:*:*:*:*:*:*",
 				}
 				assert.Equal(expectedDep, actualDep)

--- a/pkg/dependency/go_test.go
+++ b/pkg/dependency/go_test.go
@@ -2,15 +2,17 @@ package dependency_test
 
 import (
 	"errors"
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency"
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency/dependencyfakes"
-	depErrors "github.com/paketo-buildpacks/dep-server/pkg/dependency/errors"
+	"testing"
+	"time"
+
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
-	"time"
+
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency"
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency/dependencyfakes"
+	depErrors "github.com/paketo-buildpacks/dep-server/pkg/dependency/errors"
 )
 
 func TestGo(t *testing.T) {
@@ -150,7 +152,7 @@ func testGo(t *testing.T, when spec.G, it spec.S) {
 			expectedDep := dependency.DepVersion{
 				Version:         "go1.13.9",
 				URI:             "https://dl.google.com/go/go1.13.9.src.tar.gz",
-				SHA:             "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+				SHA256:          "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
 				ReleaseDate:     &expectedReleaseDate,
 				DeprecationDate: nil,
 				CPE:             "cpe:2.3:a:golang:go:1.13.9:*:*:*:*:*:*:*",
@@ -164,8 +166,8 @@ func testGo(t *testing.T, when spec.G, it spec.S) {
 			assert.Equal("https://golang.org/doc/devel/release.html", urlArg)
 		})
 
-		when("the SHA is empty", func() {
-			it("calculates the SHA", func() {
+		when("the SHA256 is empty", func() {
+			it("calculates the SHA256", func() {
 				fakeWebClient.GetReturnsOnCall(0, []byte(`
 [
 {"version": "go1.13.9", "files": [{"sha256": "", "kind": "source"}]}
@@ -189,7 +191,7 @@ func testGo(t *testing.T, when spec.G, it spec.S) {
 				expectedDep := dependency.DepVersion{
 					Version:         "go1.13.9",
 					URI:             "https://dl.google.com/go/go1.13.9.src.tar.gz",
-					SHA:             "some-source-sha",
+					SHA256:          "some-source-sha",
 					ReleaseDate:     &expectedReleaseDate,
 					DeprecationDate: nil,
 					CPE:             "cpe:2.3:a:golang:go:1.13.9:*:*:*:*:*:*:*",

--- a/pkg/dependency/httpd.go
+++ b/pkg/dependency/httpd.go
@@ -3,7 +3,6 @@ package dependency
 import (
 	"errors"
 	"fmt"
-	"github.com/Masterminds/semver"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -11,6 +10,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/Masterminds/semver"
 )
 
 type Httpd struct {
@@ -61,7 +62,7 @@ func (h Httpd) GetDependencyVersion(version string) (DepVersion, error) {
 	return DepVersion{
 		Version:     version,
 		URI:         release.dependencyURL,
-		SHA:         sha,
+		SHA256:      sha,
 		ReleaseDate: &release.releaseDate,
 		CPE:         fmt.Sprintf("cpe:2.3:a:apache:http_server:%s:*:*:*:*:*:*:*", version),
 	}, nil

--- a/pkg/dependency/httpd.go
+++ b/pkg/dependency/httpd.go
@@ -62,17 +62,17 @@ func (h Httpd) GetDependencyVersion(version string) (DepVersion, error) {
 		Version:     version,
 		URI:         release.dependencyURL,
 		SHA:         sha,
-		ReleaseDate: release.releaseDate.Format(time.RFC3339),
+		ReleaseDate: &release.releaseDate,
 		CPE:         fmt.Sprintf("cpe:2.3:a:apache:http_server:%s:*:*:*:*:*:*:*", version),
 	}, nil
 }
 
-func (h Httpd) GetReleaseDate(version string) (time.Time, error) {
+func (h Httpd) GetReleaseDate(version string) (*time.Time, error) {
 	release, err := h.getRelease(version)
 	if err != nil {
-		return time.Time{}, fmt.Errorf("could not get release: %w", err)
+		return nil, fmt.Errorf("could not get release: %w", err)
 	}
-	return release.releaseDate, nil
+	return &release.releaseDate, nil
 }
 
 func (h Httpd) getRelease(version string) (HttpdRelease, error) {

--- a/pkg/dependency/httpd_test.go
+++ b/pkg/dependency/httpd_test.go
@@ -66,6 +66,8 @@ func testHttpd(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	when("GetDependencyVersion", func() {
+		var expectedReleaseDate = time.Date(2020, 03, 30, 14, 21, 0, 0, time.UTC)
+
 		it("returns the correct httpd version", func() {
 			fakeWebClient.GetReturnsOnCall(0, []byte(httpdIndex2443), nil)
 
@@ -78,8 +80,8 @@ func testHttpd(t *testing.T, when spec.G, it spec.S) {
 				Version:         "2.4.43",
 				URI:             "http://archive.apache.org/dist/httpd/httpd-2.4.43.tar.bz2",
 				SHA:             "some-sha256",
-				ReleaseDate:     "2020-03-30T14:21:00Z",
-				DeprecationDate: "",
+				ReleaseDate:     &expectedReleaseDate,
+				DeprecationDate: nil,
 				CPE:             "cpe:2.3:a:apache:http_server:2.4.43:*:*:*:*:*:*:*",
 			}
 
@@ -108,8 +110,8 @@ func testHttpd(t *testing.T, when spec.G, it spec.S) {
 					Version:         "2.4.43",
 					URI:             "http://archive.apache.org/dist/httpd/httpd-2.4.43.tar.bz2",
 					SHA:             "some-sha256",
-					ReleaseDate:     "2020-03-30T14:21:00Z",
-					DeprecationDate: "",
+					ReleaseDate:     &expectedReleaseDate,
+					DeprecationDate: nil,
 					CPE:             "cpe:2.3:a:apache:http_server:2.4.43:*:*:*:*:*:*:*",
 				}
 
@@ -166,8 +168,8 @@ func testHttpd(t *testing.T, when spec.G, it spec.S) {
 					Version:         "2.4.43",
 					URI:             "http://archive.apache.org/dist/httpd/httpd-2.4.43.tar.bz2",
 					SHA:             "some-sha256",
-					ReleaseDate:     "2020-03-30T14:21:00Z",
-					DeprecationDate: "",
+					ReleaseDate:     &expectedReleaseDate,
+					DeprecationDate: nil,
 					CPE:             "cpe:2.3:a:apache:http_server:2.4.43:*:*:*:*:*:*:*",
 				}
 
@@ -216,12 +218,13 @@ func testHttpd(t *testing.T, when spec.G, it spec.S) {
 				actualDepVersion, err := httpd.GetDependencyVersion("2.2.3")
 				require.NoError(err)
 
+				expectedReleaseDate223 := time.Date(2006, 07, 27, 17, 39, 0, 0, time.UTC)
 				expectedDepVersion := dependency.DepVersion{
 					Version:         "2.2.3",
 					URI:             "http://archive.apache.org/dist/httpd/httpd-2.2.3.tar.bz2",
 					SHA:             "some-sha256",
-					ReleaseDate:     "2006-07-27T17:39:00Z",
-					DeprecationDate: "",
+					ReleaseDate:     &expectedReleaseDate223,
+					DeprecationDate: nil,
 					CPE:             "cpe:2.3:a:apache:http_server:2.2.3:*:*:*:*:*:*:*",
 				}
 

--- a/pkg/dependency/httpd_test.go
+++ b/pkg/dependency/httpd_test.go
@@ -2,15 +2,17 @@ package dependency_test
 
 import (
 	"fmt"
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency"
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency/dependencyfakes"
+	"regexp"
+	"testing"
+	"time"
+
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"regexp"
-	"testing"
-	"time"
+
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency"
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency/dependencyfakes"
 )
 
 func TestHttpd(t *testing.T) {
@@ -79,7 +81,7 @@ func testHttpd(t *testing.T, when spec.G, it spec.S) {
 			expectedDepVersion := dependency.DepVersion{
 				Version:         "2.4.43",
 				URI:             "http://archive.apache.org/dist/httpd/httpd-2.4.43.tar.bz2",
-				SHA:             "some-sha256",
+				SHA256:          "some-sha256",
 				ReleaseDate:     &expectedReleaseDate,
 				DeprecationDate: nil,
 				CPE:             "cpe:2.3:a:apache:http_server:2.4.43:*:*:*:*:*:*:*",
@@ -109,7 +111,7 @@ func testHttpd(t *testing.T, when spec.G, it spec.S) {
 				expectedDepVersion := dependency.DepVersion{
 					Version:         "2.4.43",
 					URI:             "http://archive.apache.org/dist/httpd/httpd-2.4.43.tar.bz2",
-					SHA:             "some-sha256",
+					SHA256:          "some-sha256",
 					ReleaseDate:     &expectedReleaseDate,
 					DeprecationDate: nil,
 					CPE:             "cpe:2.3:a:apache:http_server:2.4.43:*:*:*:*:*:*:*",
@@ -143,7 +145,7 @@ func testHttpd(t *testing.T, when spec.G, it spec.S) {
 					depVersion, err := httpd.GetDependencyVersion("2.4.43")
 					require.NoError(err)
 
-					assert.Equal("some-sha256", depVersion.SHA)
+					assert.Equal("some-sha256", depVersion.SHA256)
 
 					_, checksumArg := fakeChecksummer.VerifySHA1ArgsForCall(0)
 					assert.Equal("some-sha1", checksumArg)
@@ -167,7 +169,7 @@ func testHttpd(t *testing.T, when spec.G, it spec.S) {
 				expectedDepVersion := dependency.DepVersion{
 					Version:         "2.4.43",
 					URI:             "http://archive.apache.org/dist/httpd/httpd-2.4.43.tar.bz2",
-					SHA:             "some-sha256",
+					SHA256:          "some-sha256",
 					ReleaseDate:     &expectedReleaseDate,
 					DeprecationDate: nil,
 					CPE:             "cpe:2.3:a:apache:http_server:2.4.43:*:*:*:*:*:*:*",
@@ -202,7 +204,7 @@ func testHttpd(t *testing.T, when spec.G, it spec.S) {
 					depVersion, err := httpd.GetDependencyVersion("2.4.43")
 					require.NoError(err)
 
-					assert.Equal("some-sha256", depVersion.SHA)
+					assert.Equal("some-sha256", depVersion.SHA256)
 
 					_, checksumArg := fakeChecksummer.VerifyMD5ArgsForCall(0)
 					assert.Equal("some-md5", checksumArg)
@@ -222,7 +224,7 @@ func testHttpd(t *testing.T, when spec.G, it spec.S) {
 				expectedDepVersion := dependency.DepVersion{
 					Version:         "2.2.3",
 					URI:             "http://archive.apache.org/dist/httpd/httpd-2.2.3.tar.bz2",
-					SHA:             "some-sha256",
+					SHA256:          "some-sha256",
 					ReleaseDate:     &expectedReleaseDate223,
 					DeprecationDate: nil,
 					CPE:             "cpe:2.3:a:apache:http_server:2.2.3:*:*:*:*:*:*:*",

--- a/pkg/dependency/icu.go
+++ b/pkg/dependency/icu.go
@@ -4,14 +4,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	depErrors "github.com/paketo-buildpacks/dep-server/pkg/dependency/errors"
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency/internal"
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency/internal/internal_errors"
 	"io/ioutil"
 	"path/filepath"
 	"sort"
 	"strings"
 	"time"
+
+	depErrors "github.com/paketo-buildpacks/dep-server/pkg/dependency/errors"
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency/internal"
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency/internal/internal_errors"
 )
 
 type ICU struct {
@@ -136,7 +137,7 @@ func (i ICU) createDependencyVersion(version string, release internal.GithubRele
 	return DepVersion{
 		Version:         version,
 		URI:             asset.BrowserDownloadUrl,
-		SHA:             dependencySHA,
+		SHA256:          dependencySHA,
 		ReleaseDate:     &release.CreatedDate,
 		DeprecationDate: nil,
 		CPE:             fmt.Sprintf(`cpe:2.3:a:icu-project:international_components_for_unicode:%s:*:*:*:*:c\/c\+\+:*:*`, version),

--- a/pkg/dependency/icu_test.go
+++ b/pkg/dependency/icu_test.go
@@ -2,17 +2,19 @@ package dependency_test
 
 import (
 	"errors"
+	"testing"
+	"time"
+
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/paketo-buildpacks/dep-server/pkg/dependency"
 	"github.com/paketo-buildpacks/dep-server/pkg/dependency/dependencyfakes"
 	depErrors "github.com/paketo-buildpacks/dep-server/pkg/dependency/errors"
 	"github.com/paketo-buildpacks/dep-server/pkg/dependency/internal"
 	"github.com/paketo-buildpacks/dep-server/pkg/dependency/internal/internal_errors"
-	"github.com/sclevine/spec"
-	"github.com/sclevine/spec/report"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"testing"
-	"time"
 )
 
 func TestICU(t *testing.T) {
@@ -102,7 +104,7 @@ func testICU(t *testing.T, when spec.G, it spec.S) {
 			expectedDep := dependency.DepVersion{
 				Version:         "66.1",
 				URI:             "some-source-url",
-				SHA:             "some-source-sha",
+				SHA256:          "some-source-sha",
 				ReleaseDate:     &expectedReleaseDate,
 				DeprecationDate: nil,
 				CPE:             `cpe:2.3:a:icu-project:international_components_for_unicode:66.1:*:*:*:*:c\/c\+\+:*:*`,
@@ -153,7 +155,7 @@ func testICU(t *testing.T, when spec.G, it spec.S) {
 				expectedDep := dependency.DepVersion{
 					Version:         "4.8.2",
 					URI:             "some-source-url",
-					SHA:             "some-source-sha",
+					SHA256:          "some-source-sha",
 					ReleaseDate:     &expectedReleaseDate,
 					DeprecationDate: nil,
 					CPE:             `cpe:2.3:a:icu-project:international_components_for_unicode:4.8.2:*:*:*:*:c\/c\+\+:*:*`,

--- a/pkg/dependency/icu_test.go
+++ b/pkg/dependency/icu_test.go
@@ -44,17 +44,17 @@ func testICU(t *testing.T, when spec.G, it spec.S) {
 	when("GetAllVersionRefs", func() {
 		it("returns all ICU release versions with newest versions first", func() {
 			fakeGithubClient.GetReleaseTagsReturns([]internal.GithubRelease{
-				{TagName: "release-59-1", CreatedDate: "2017-04-13T13:46:59Z"},
-				{TagName: "release-60-1", CreatedDate: "2017-10-31T15:14:15Z"},
-				{TagName: "release-60-2", CreatedDate: "2017-12-13T20:01:38Z"},
-				{TagName: "release-67-1", CreatedDate: "2020-04-22T17:49:10Z"},
-				{TagName: "release-66-1", CreatedDate: "2020-03-11T17:21:07Z"},
-				{TagName: "release-66-1-99", CreatedDate: "2020-03-12T17:21:07Z"},
-				{TagName: "release-65-1", CreatedDate: "2019-10-02T21:30:54Z"},
-				{TagName: "release-60-3", CreatedDate: "2019-04-11T18:44:36Z"},
-				{TagName: "release-59-2", CreatedDate: "2019-04-11T18:43:42Z"},
-				{TagName: "release-4-8-2", CreatedDate: "2019-04-11T18:17:52Z"},
-				{TagName: "release-99-99", CreatedDate: "2019-04-11T18:17:52Z"},
+				{TagName: "release-59-1", CreatedDate: time.Date(2017, 04, 13, 13, 46, 59, 0, time.UTC)},
+				{TagName: "release-60-1", CreatedDate: time.Date(2017, 10, 31, 15, 14, 15, 0, time.UTC)},
+				{TagName: "release-60-2", CreatedDate: time.Date(2017, 12, 13, 20, 01, 38, 0, time.UTC)},
+				{TagName: "release-67-1", CreatedDate: time.Date(2020, 04, 22, 17, 49, 10, 0, time.UTC)},
+				{TagName: "release-66-1", CreatedDate: time.Date(2020, 03, 11, 17, 21, 07, 0, time.UTC)},
+				{TagName: "release-66-1-99", CreatedDate: time.Date(2020, 03, 12, 17, 21, 07, 0, time.UTC)},
+				{TagName: "release-65-1", CreatedDate: time.Date(2019, 10, 02, 21, 30, 54, 0, time.UTC)},
+				{TagName: "release-60-3", CreatedDate: time.Date(2019, 04, 11, 18, 44, 36, 0, time.UTC)},
+				{TagName: "release-59-2", CreatedDate: time.Date(2019, 04, 11, 18, 43, 42, 0, time.UTC)},
+				{TagName: "release-4-8-2", CreatedDate: time.Date(2019, 04, 11, 18, 17, 52, 0, time.UTC)},
+				{TagName: "release-99-99", CreatedDate: time.Date(2019, 04, 11, 18, 17, 52, 0, time.UTC)},
 			}, nil)
 
 			versions, err := icu.GetAllVersionRefs()
@@ -83,9 +83,9 @@ func testICU(t *testing.T, when spec.G, it spec.S) {
 	when("GetDependencyVersion", func() {
 		it("returns the correct ICU version", func() {
 			fakeGithubClient.GetReleaseTagsReturns([]internal.GithubRelease{
-				{TagName: "release-67-1", CreatedDate: "2020-04-22T17:49:10Z"},
-				{TagName: "release-66-1", CreatedDate: "2020-03-11T17:21:07Z"},
-				{TagName: "release-65-1", CreatedDate: "2019-10-02T21:30:54Z"},
+				{TagName: "release-67-1", CreatedDate: time.Date(2020, 04, 22, 17, 49, 10, 0, time.UTC)},
+				{TagName: "release-66-1", CreatedDate: time.Date(2020, 03, 11, 17, 21, 07, 0, time.UTC)},
+				{TagName: "release-65-1", CreatedDate: time.Date(2020, 10, 02, 21, 30, 54, 0, time.UTC)},
 			}, nil)
 			assetUrlContent := `{"browser_download_url":"some-source-url", "key":"some_value"}`
 			fakeWebClient.GetReturnsOnCall(0, []byte("some-gpg-key"), nil)
@@ -98,12 +98,13 @@ func testICU(t *testing.T, when spec.G, it spec.S) {
 			actualDep, err := icu.GetDependencyVersion("66.1")
 			require.NoError(err)
 
+			expectedReleaseDate := time.Date(2020, 03, 11, 17, 21, 07, 0, time.UTC)
 			expectedDep := dependency.DepVersion{
 				Version:         "66.1",
 				URI:             "some-source-url",
 				SHA:             "some-source-sha",
-				ReleaseDate:     "2020-03-11T17:21:07Z",
-				DeprecationDate: "",
+				ReleaseDate:     &expectedReleaseDate,
+				DeprecationDate: nil,
 				CPE:             `cpe:2.3:a:icu-project:international_components_for_unicode:66.1:*:*:*:*:c\/c\+\+:*:*`,
 			}
 
@@ -134,9 +135,9 @@ func testICU(t *testing.T, when spec.G, it spec.S) {
 		when("getting a version prior to 49", func() {
 			it("returns the correct ICU version", func() {
 				fakeGithubClient.GetReleaseTagsReturns([]internal.GithubRelease{
-					{TagName: "release-4-8-3", CreatedDate: "2019-04-12T18:17:52Z"},
-					{TagName: "release-4-8-2", CreatedDate: "2019-04-11T18:17:52Z"},
-					{TagName: "release-4-8-1", CreatedDate: "2019-04-10T18:17:52Z"},
+					{TagName: "release-4-8-3", CreatedDate: time.Date(2019, 04, 12, 18, 17, 52, 0, time.UTC)},
+					{TagName: "release-4-8-2", CreatedDate: time.Date(2019, 04, 11, 18, 17, 52, 0, time.UTC)},
+					{TagName: "release-4-8-1", CreatedDate: time.Date(2019, 04, 10, 18, 17, 52, 0, time.UTC)},
 				}, nil)
 				assetUrlContent := `{"browser_download_url":"some-source-url", "key":"some_value"}`
 				fakeWebClient.GetReturnsOnCall(0, []byte("some-gpg-key"), nil)
@@ -148,12 +149,13 @@ func testICU(t *testing.T, when spec.G, it spec.S) {
 				actualDep, err := icu.GetDependencyVersion("4.8.2")
 				require.NoError(err)
 
+				expectedReleaseDate := time.Date(2019, 04, 11, 18, 17, 52, 0, time.UTC)
 				expectedDep := dependency.DepVersion{
 					Version:         "4.8.2",
 					URI:             "some-source-url",
 					SHA:             "some-source-sha",
-					ReleaseDate:     "2019-04-11T18:17:52Z",
-					DeprecationDate: "",
+					ReleaseDate:     &expectedReleaseDate,
+					DeprecationDate: nil,
 					CPE:             `cpe:2.3:a:icu-project:international_components_for_unicode:4.8.2:*:*:*:*:c\/c\+\+:*:*`,
 				}
 
@@ -179,7 +181,7 @@ func testICU(t *testing.T, when spec.G, it spec.S) {
 		when("the asset cannot be found", func() {
 			it("returns a NoSourceCode error", func() {
 				fakeGithubClient.GetReleaseTagsReturns([]internal.GithubRelease{
-					{TagName: "release-66-1", CreatedDate: "2020-03-11T17:21:07Z"},
+					{TagName: "release-66-1", CreatedDate: time.Date(2020, 03, 11, 17, 21, 07, 0, time.UTC)},
 				}, nil)
 				assetUrlContent := `{"browser_download_url":"some-source-url", "key":"some_value"}`
 				fakeWebClient.GetReturnsOnCall(0, []byte("some-gpg-key"), nil)
@@ -197,9 +199,9 @@ func testICU(t *testing.T, when spec.G, it spec.S) {
 	when("GetReleaseDate", func() {
 		it("returns the correct ICU release date", func() {
 			fakeGithubClient.GetReleaseTagsReturns([]internal.GithubRelease{
-				{TagName: "release-67-1", CreatedDate: "2020-04-22T17:49:10Z"},
-				{TagName: "release-66-1", CreatedDate: "2020-03-11T17:21:07Z"},
-				{TagName: "release-65-1", CreatedDate: "2019-10-02T21:30:54Z"},
+				{TagName: "release-67-1", CreatedDate: time.Date(2020, 04, 22, 17, 49, 10, 0, time.UTC)},
+				{TagName: "release-66-1", CreatedDate: time.Date(2020, 03, 11, 17, 21, 07, 0, time.UTC)},
+				{TagName: "release-65-1", CreatedDate: time.Date(2019, 10, 02, 21, 30, 54, 0, time.UTC)},
 			}, nil)
 
 			releaseDate, err := icu.GetReleaseDate("66.1")

--- a/pkg/dependency/internal/checksummer.go
+++ b/pkg/dependency/internal/checksummer.go
@@ -57,11 +57,11 @@ func (c Checksummer) VerifyMD5(path, expectedMD5 string) error {
 func (c Checksummer) VerifySHA1(path, expectedSHA string) error {
 	actualSHA, err := c.getSHA1(path)
 	if err != nil {
-		return fmt.Errorf("failed to get actual SHA: %w", err)
+		return fmt.Errorf("failed to get actual SHA256: %w", err)
 	}
 
 	if actualSHA != expectedSHA {
-		return fmt.Errorf("expected SHA '%s' but got '%s'", expectedSHA, actualSHA)
+		return fmt.Errorf("expected SHA256 '%s' but got '%s'", expectedSHA, actualSHA)
 	}
 
 	return nil
@@ -70,11 +70,11 @@ func (c Checksummer) VerifySHA1(path, expectedSHA string) error {
 func (c Checksummer) VerifySHA256(path, expectedSHA string) error {
 	actualSHA, err := c.GetSHA256(path)
 	if err != nil {
-		return fmt.Errorf("failed to get actual SHA: %w", err)
+		return fmt.Errorf("failed to get actual SHA256: %w", err)
 	}
 
 	if actualSHA != expectedSHA {
-		return fmt.Errorf("expected SHA '%s' but got '%s'", expectedSHA, actualSHA)
+		return fmt.Errorf("expected SHA256 '%s' but got '%s'", expectedSHA, actualSHA)
 	}
 
 	return nil
@@ -83,11 +83,11 @@ func (c Checksummer) VerifySHA256(path, expectedSHA string) error {
 func (c Checksummer) VerifySHA512(path, expectedSHA string) error {
 	actualSHA, err := c.GetSHA512(path)
 	if err != nil {
-		return fmt.Errorf("failed to get actual SHA: %w", err)
+		return fmt.Errorf("failed to get actual SHA256: %w", err)
 	}
 
 	if actualSHA != expectedSHA {
-		return fmt.Errorf("expected SHA '%s' but got '%s'", expectedSHA, actualSHA)
+		return fmt.Errorf("expected SHA256 '%s' but got '%s'", expectedSHA, actualSHA)
 	}
 
 	return nil
@@ -103,7 +103,7 @@ func (c Checksummer) GetSHA256(path string) (string, error) {
 	hash := sha256.New()
 	_, err = io.Copy(hash, file)
 	if err != nil {
-		return "nil", fmt.Errorf("failed to calculate SHA: %w", err)
+		return "nil", fmt.Errorf("failed to calculate SHA256: %w", err)
 	}
 
 	return fmt.Sprintf("%x", hash.Sum(nil)), nil
@@ -119,7 +119,7 @@ func (c Checksummer) GetSHA512(path string) (string, error) {
 	hash := sha512.New()
 	_, err = io.Copy(hash, file)
 	if err != nil {
-		return "nil", fmt.Errorf("failed to calculate SHA: %w", err)
+		return "nil", fmt.Errorf("failed to calculate SHA256: %w", err)
 	}
 
 	return fmt.Sprintf("%x", hash.Sum(nil)), nil

--- a/pkg/dependency/internal/checksummer_test.go
+++ b/pkg/dependency/internal/checksummer_test.go
@@ -169,11 +169,11 @@ KbtkeGcVHGGJtT8krUQB6f3VPT2vQg==
 			require.NoError(err)
 		})
 
-		when("the SHA does not match", func() {
+		when("the SHA256 does not match", func() {
 			it("returns an error", func() {
 				err := checksummer.VerifySHA1(filePath, "some-bad-sha")
 				assert.Error(err)
-				assert.Equal("expected SHA 'some-bad-sha' but got '21202296bf50267250155e46d3b9eb3e4c1acb7e'", err.Error())
+				assert.Equal("expected SHA256 'some-bad-sha' but got '21202296bf50267250155e46d3b9eb3e4c1acb7e'", err.Error())
 			})
 		})
 	})
@@ -184,11 +184,11 @@ KbtkeGcVHGGJtT8krUQB6f3VPT2vQg==
 			require.NoError(err)
 		})
 
-		when("the SHA does not match", func() {
+		when("the SHA256 does not match", func() {
 			it("returns an error", func() {
 				err := checksummer.VerifySHA256(filePath, "some-bad-sha")
 				assert.Error(err)
-				assert.Equal("expected SHA 'some-bad-sha' but got '6e32ea34db1b3755d7dec972eb72c705338f0dd8e0be881d966963438fb2e800'", err.Error())
+				assert.Equal("expected SHA256 'some-bad-sha' but got '6e32ea34db1b3755d7dec972eb72c705338f0dd8e0be881d966963438fb2e800'", err.Error())
 			})
 		})
 	})
@@ -199,11 +199,11 @@ KbtkeGcVHGGJtT8krUQB6f3VPT2vQg==
 			require.NoError(err)
 		})
 
-		when("the SHA does not match", func() {
+		when("the SHA256 does not match", func() {
 			it("returns an error", func() {
 				err := checksummer.VerifySHA512(filePath, "some-bad-sha")
 				assert.Error(err)
-				assert.Equal("expected SHA 'some-bad-sha' but got 'b7b2b9e0a4d7f84985a720d1273166bb00132a60ac45388a7d3090a7d4c9692f38d019f807a02750f810f52c623362f977040231c2bbf5947170fe83686cfd9d'", err.Error())
+				assert.Equal("expected SHA256 'some-bad-sha' but got 'b7b2b9e0a4d7f84985a720d1273166bb00132a60ac45388a7d3090a7d4c9692f38d019f807a02750f810f52c623362f977040231c2bbf5947170fe83686cfd9d'", err.Error())
 			})
 		})
 	})

--- a/pkg/dependency/internal/github_client.go
+++ b/pkg/dependency/internal/github_client.go
@@ -3,6 +3,8 @@ package internal
 import (
 	"encoding/json"
 	"fmt"
+	"time"
+
 	"github.com/paketo-buildpacks/dep-server/pkg/dependency/internal/internal_errors"
 )
 
@@ -11,8 +13,8 @@ type GithubReleaseResponse struct {
 	Draft       bool                 `json:"draft"`
 	Prerelease  bool                 `json:"prerelease"`
 	Assets      []GithubReleaseAsset `json:"assets"`
-	PublishedAt string               `json:"published_at"`
-	CreatedAt   string               `json:"created_at"`
+	PublishedAt time.Time            `json:"published_at"`
+	CreatedAt   time.Time            `json:"created_at"`
 }
 
 type GithubReleaseAsset struct {
@@ -22,8 +24,8 @@ type GithubReleaseAsset struct {
 
 type GithubRelease struct {
 	TagName       string
-	PublishedDate string
-	CreatedDate   string
+	PublishedDate time.Time
+	CreatedDate   time.Time
 }
 
 type GithubTagResponse struct {
@@ -35,14 +37,14 @@ type GithubTagResponse struct {
 type GithubTagCommit struct {
 	Tag  string
 	SHA  string
-	Date string
+	Date time.Time
 }
 
 type GithubCommitResponse struct {
 	SHA    string `json:"sha"`
 	Commit struct {
 		Committer struct {
-			Date string `json:"date"`
+			Date time.Time `json:"date"`
 		} `json:"committer"`
 	} `json:"commit"`
 }

--- a/pkg/dependency/internal/github_client_test.go
+++ b/pkg/dependency/internal/github_client_test.go
@@ -2,15 +2,18 @@ package internal_test
 
 import (
 	"errors"
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency/internal"
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency/internal/internal_errors"
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency/internal/internalfakes"
+	"net/http"
+	"testing"
+	"time"
+
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"net/http"
-	"testing"
+
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency/internal"
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency/internal/internal_errors"
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency/internal/internalfakes"
 )
 
 func TestGithubClient(t *testing.T) {
@@ -52,21 +55,21 @@ func testGithubClient(t *testing.T, when spec.G, it spec.S) {
 			actualReleases, err := githubClient.GetReleaseTags("some-org", "some-repo")
 			require.NoError(err)
 
-			expectedRelases := []internal.GithubRelease{
+			expectedReleases := []internal.GithubRelease{
 				{
 					TagName:       "v1.0.1",
-					PublishedDate: "2020-06-30T00:00:00Z",
+					PublishedDate: time.Date(2020, 06, 30, 0, 0, 0, 0, time.UTC),
 				},
 				{
 					TagName:       "v2.0.0",
-					PublishedDate: "2020-06-29T00:00:00Z",
+					PublishedDate: time.Date(2020, 06, 29, 0, 0, 0, 0, time.UTC),
 				},
 				{
 					TagName:       "v1.0.0",
-					PublishedDate: "2020-06-27T00:00:00Z",
+					PublishedDate: time.Date(2020, 06, 27, 0, 0, 0, 0, time.UTC),
 				},
 			}
-			assert.Equal(expectedRelases, actualReleases)
+			assert.Equal(expectedReleases, actualReleases)
 
 			urlArg, optionsArg := fakeWebClient.GetArgsForCall(0)
 			assert.Equal("https://api.github.com/repos/some-org/some-repo/releases?per_page=100&page=1", urlArg)
@@ -268,7 +271,7 @@ func testGithubClient(t *testing.T, when spec.G, it spec.S) {
 			expectedTagCommit := internal.GithubTagCommit{
 				Tag:  "1.0.0",
 				SHA:  "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-				Date: "2020-01-31T00:00:00Z",
+				Date: time.Date(2020, 01, 31, 0, 0, 0, 0, time.UTC),
 			}
 
 			assert.Equal(expectedTagCommit, actualTagCommit)

--- a/pkg/dependency/nginx.go
+++ b/pkg/dependency/nginx.go
@@ -45,7 +45,7 @@ func (n Nginx) GetDependencyVersion(version string) (DepVersion, error) {
 	return DepVersion{
 		Version:         version,
 		URI:             dependencyURL,
-		SHA:             sha,
+		SHA256:          sha,
 		ReleaseDate:     &tagCommit.Date,
 		DeprecationDate: nil,
 		CPE:             fmt.Sprintf("cpe:2.3:a:nginx:nginx:%s:*:*:*:*:*:*:*", version),

--- a/pkg/dependency/nginx.go
+++ b/pkg/dependency/nginx.go
@@ -46,25 +46,20 @@ func (n Nginx) GetDependencyVersion(version string) (DepVersion, error) {
 		Version:         version,
 		URI:             dependencyURL,
 		SHA:             sha,
-		ReleaseDate:     tagCommit.Date,
-		DeprecationDate: "",
+		ReleaseDate:     &tagCommit.Date,
+		DeprecationDate: nil,
 		CPE:             fmt.Sprintf("cpe:2.3:a:nginx:nginx:%s:*:*:*:*:*:*:*", version),
 	}, nil
 }
 
-func (n Nginx) GetReleaseDate(version string) (time.Time, error) {
+func (n Nginx) GetReleaseDate(version string) (*time.Time, error) {
 	tagName := "release-" + version
 	tagCommit, err := n.githubClient.GetTagCommit("nginx", "nginx", tagName)
 	if err != nil {
-		return time.Time{}, fmt.Errorf("could not get tags: %w", err)
+		return nil, fmt.Errorf("could not get tags: %w", err)
 	}
 
-	releaseDate, err := time.Parse(time.RFC3339, tagCommit.Date)
-	if err != nil {
-		return time.Time{}, fmt.Errorf("could not parse release date: %w", err)
-	}
-
-	return releaseDate, nil
+	return &tagCommit.Date, nil
 }
 
 func (n Nginx) getDependencySHA(dependencyURL, version string) (string, error) {

--- a/pkg/dependency/nginx_test.go
+++ b/pkg/dependency/nginx_test.go
@@ -1,15 +1,17 @@
 package dependency_test
 
 import (
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency"
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency/dependencyfakes"
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency/internal"
+	"testing"
+	"time"
+
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
-	"time"
+
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency"
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency/dependencyfakes"
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency/internal"
 )
 
 func TestNginx(t *testing.T) {
@@ -77,7 +79,7 @@ func testNginx(t *testing.T, when spec.G, it spec.S) {
 			expectedDepVersion := dependency.DepVersion{
 				Version:         "1.0.0",
 				URI:             "http://nginx.org/download/nginx-1.0.0.tar.gz",
-				SHA:             "some-source-sha",
+				SHA256:          "some-source-sha",
 				ReleaseDate:     &expectedReleaseDate,
 				DeprecationDate: nil,
 				CPE:             "cpe:2.3:a:nginx:nginx:1.0.0:*:*:*:*:*:*:*",

--- a/pkg/dependency/nginx_test.go
+++ b/pkg/dependency/nginx_test.go
@@ -64,7 +64,7 @@ func testNginx(t *testing.T, when spec.G, it spec.S) {
 			fakeGithubClient.GetTagCommitReturns(internal.GithubTagCommit{
 				Tag:  "release-1.0.0",
 				SHA:  "dddddddddddddddddddddddddddddddddddddddd",
-				Date: "2020-06-17T00:00:00Z",
+				Date: time.Date(2020, 06, 17, 0, 0, 0, 0, time.UTC),
 			}, nil)
 			fakeWebClient.GetReturnsOnCall(0, []byte("some-gpg-key"), nil)
 			fakeWebClient.GetReturnsOnCall(1, []byte("some-signature"), nil)
@@ -73,12 +73,13 @@ func testNginx(t *testing.T, when spec.G, it spec.S) {
 			actualDepVersion, err := nginx.GetDependencyVersion("1.0.0")
 			require.NoError(err)
 
+			expectedReleaseDate := time.Date(2020, 06, 17, 0, 0, 0, 0, time.UTC)
 			expectedDepVersion := dependency.DepVersion{
 				Version:         "1.0.0",
 				URI:             "http://nginx.org/download/nginx-1.0.0.tar.gz",
 				SHA:             "some-source-sha",
-				ReleaseDate:     "2020-06-17T00:00:00Z",
-				DeprecationDate: "",
+				ReleaseDate:     &expectedReleaseDate,
+				DeprecationDate: nil,
 				CPE:             "cpe:2.3:a:nginx:nginx:1.0.0:*:*:*:*:*:*:*",
 			}
 			assert.Equal(expectedDepVersion, actualDepVersion)
@@ -100,7 +101,7 @@ func testNginx(t *testing.T, when spec.G, it spec.S) {
 			fakeGithubClient.GetTagCommitReturns(internal.GithubTagCommit{
 				Tag:  "release-1.0.0",
 				SHA:  "dddddddddddddddddddddddddddddddddddddddd",
-				Date: "2020-06-17T00:00:00Z",
+				Date: time.Date(2020, 06, 17, 0, 0, 0, 0, time.UTC),
 			}, nil)
 
 			releaseDate, err := nginx.GetReleaseDate("1.0.0")

--- a/pkg/dependency/node.go
+++ b/pkg/dependency/node.go
@@ -103,7 +103,7 @@ func (n Node) createDepVersion(release NodeRelease, releaseSchedule ReleaseSched
 	deprecationDate := n.getDeprecationDate(release.Version, releaseSchedule)
 	sha, err := n.getDependencySHA(release.Version)
 	if err != nil {
-		return DepVersion{}, fmt.Errorf("could not get dependency SHA: %w", err)
+		return DepVersion{}, fmt.Errorf("could not get dependency SHA256: %w", err)
 	}
 
 	releaseDate, err := time.Parse("2006-01-02", release.Date)
@@ -114,7 +114,7 @@ func (n Node) createDepVersion(release NodeRelease, releaseSchedule ReleaseSched
 	return DepVersion{
 		Version:         release.Version,
 		URI:             n.dependencyURL(release.Version),
-		SHA:             sha,
+		SHA256:          sha,
 		ReleaseDate:     &releaseDate,
 		DeprecationDate: deprecationDate,
 		CPE:             fmt.Sprintf("cpe:2.3:a:nodejs:node.js:%s:*:*:*:*:*:*:*", strings.TrimPrefix(release.Version, "v")),
@@ -159,7 +159,7 @@ func (n Node) getDeprecationDate(version string, releaseSchedule ReleaseSchedule
 func (n Node) getDependencySHA(version string) (string, error) {
 	body, err := n.webClient.Get(n.shaFileURL(version))
 	if err != nil {
-		return "", fmt.Errorf("could not get SHA file: %w", err)
+		return "", fmt.Errorf("could not get SHA256 file: %w", err)
 	}
 
 	var dependencySHA string
@@ -169,7 +169,7 @@ func (n Node) getDependencySHA(version string) (string, error) {
 		}
 	}
 	if dependencySHA == "" {
-		return "", fmt.Errorf("could not find SHA for node-%s.tar.gz", version)
+		return "", fmt.Errorf("could not find SHA256 for node-%s.tar.gz", version)
 	}
 	return dependencySHA, nil
 }

--- a/pkg/dependency/node_test.go
+++ b/pkg/dependency/node_test.go
@@ -104,12 +104,14 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  node-v13.9.0.t
 
 			require.NoError(err)
 
+			expectedReleaseDate := time.Date(2020, 02, 20, 0, 0, 0, 0, time.UTC)
+			expectedDeprecationDate := time.Date(2020, 06, 01, 0, 0, 0, 0, time.UTC)
 			expectedDep := dependency.DepVersion{
 				Version:         "v13.9.0",
 				URI:             "https://nodejs.org/dist/v13.9.0/node-v13.9.0.tar.gz",
 				SHA:             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-				ReleaseDate:     "2020-02-20T00:00:00Z",
-				DeprecationDate: "2020-06-01T00:00:00Z",
+				ReleaseDate:     &expectedReleaseDate,
+				DeprecationDate: &expectedDeprecationDate,
 				CPE:             "cpe:2.3:a:nodejs:node.js:13.9.0:*:*:*:*:*:*:*",
 			}
 
@@ -142,12 +144,14 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  node-v0.8.0.ta
 
 				require.NoError(err)
 
+				expectedReleaseDate := time.Date(2015, 01, 30, 0, 0, 0, 0, time.UTC)
+				expectedDeprecationDate := time.Date(2016, 06, 01, 0, 0, 0, 0, time.UTC)
 				expectedDep := dependency.DepVersion{
 					Version:         "v0.8.0",
 					URI:             "https://nodejs.org/dist/v0.8.0/node-v0.8.0.tar.gz",
 					SHA:             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-					ReleaseDate:     "2015-01-30T00:00:00Z",
-					DeprecationDate: "2016-06-01T00:00:00Z",
+					ReleaseDate:     &expectedReleaseDate,
+					DeprecationDate: &expectedDeprecationDate,
 					CPE:             "cpe:2.3:a:nodejs:node.js:0.8.0:*:*:*:*:*:*:*",
 				}
 
@@ -178,12 +182,13 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  node-v13.9.0.t
 
 				require.NoError(err)
 
+				expectedReleaseDate := time.Date(2020, 01, 30, 0, 0, 0, 0, time.UTC)
 				expectedDep := dependency.DepVersion{
 					Version:         "v13.9.0",
 					URI:             "https://nodejs.org/dist/v13.9.0/node-v13.9.0.tar.gz",
 					SHA:             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-					ReleaseDate:     "2020-01-30T00:00:00Z",
-					DeprecationDate: "",
+					ReleaseDate:     &expectedReleaseDate,
+					DeprecationDate: nil,
 					CPE:             "cpe:2.3:a:nodejs:node.js:13.9.0:*:*:*:*:*:*:*",
 				}
 

--- a/pkg/dependency/node_test.go
+++ b/pkg/dependency/node_test.go
@@ -1,14 +1,16 @@
 package dependency_test
 
 import (
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency"
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency/dependencyfakes"
+	"testing"
+	"time"
+
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
-	"time"
+
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency"
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency/dependencyfakes"
 )
 
 func TestNode(t *testing.T) {
@@ -109,7 +111,7 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  node-v13.9.0.t
 			expectedDep := dependency.DepVersion{
 				Version:         "v13.9.0",
 				URI:             "https://nodejs.org/dist/v13.9.0/node-v13.9.0.tar.gz",
-				SHA:             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				SHA256:          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				ReleaseDate:     &expectedReleaseDate,
 				DeprecationDate: &expectedDeprecationDate,
 				CPE:             "cpe:2.3:a:nodejs:node.js:13.9.0:*:*:*:*:*:*:*",
@@ -149,7 +151,7 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  node-v0.8.0.ta
 				expectedDep := dependency.DepVersion{
 					Version:         "v0.8.0",
 					URI:             "https://nodejs.org/dist/v0.8.0/node-v0.8.0.tar.gz",
-					SHA:             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+					SHA256:          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 					ReleaseDate:     &expectedReleaseDate,
 					DeprecationDate: &expectedDeprecationDate,
 					CPE:             "cpe:2.3:a:nodejs:node.js:0.8.0:*:*:*:*:*:*:*",
@@ -186,7 +188,7 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  node-v13.9.0.t
 				expectedDep := dependency.DepVersion{
 					Version:         "v13.9.0",
 					URI:             "https://nodejs.org/dist/v13.9.0/node-v13.9.0.tar.gz",
-					SHA:             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+					SHA256:          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 					ReleaseDate:     &expectedReleaseDate,
 					DeprecationDate: nil,
 					CPE:             "cpe:2.3:a:nodejs:node.js:13.9.0:*:*:*:*:*:*:*",
@@ -210,7 +212,7 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  node-v13.9.0.t
 			})
 		})
 
-		when("the SHA cannot be found", func() {
+		when("the SHA256 cannot be found", func() {
 			it("returns an error", func() {
 				fakeWebClient.GetReturnsOnCall(0, []byte(`
 		[
@@ -229,7 +231,7 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  node-v13.9.0.t
 				fakeWebClient.GetReturnsOnCall(2, nil, nil)
 				_, err := node.GetDependencyVersion("v14.0.0")
 				assert.Error(err)
-				assert.Contains(err.Error(), "could not find SHA for node-v14.0.0.tar.gz")
+				assert.Contains(err.Error(), "could not find SHA256 for node-v14.0.0.tar.gz")
 			})
 		})
 	})

--- a/pkg/dependency/php.go
+++ b/pkg/dependency/php.go
@@ -77,7 +77,7 @@ func (p Php) GetDependencyVersion(version string) (DepVersion, error) {
 	return DepVersion{
 		Version:         version,
 		URI:             dependencyURL,
-		SHA:             dependencySHA,
+		SHA256:          dependencySHA,
 		ReleaseDate:     releaseDate,
 		DeprecationDate: deprecationDate,
 		CPE:             fmt.Sprintf("cpe:2.3:a:php:php:%s:*:*:*:*:*:*:*", version),
@@ -174,7 +174,7 @@ func (p Php) getDependencySHA(release PhpRawRelease, version string) (string, er
 
 				return sha, nil
 			} else {
-				return "", fmt.Errorf("could not find SHA or MD5 for %s", version)
+				return "", fmt.Errorf("could not find SHA256 or MD5 for %s", version)
 			}
 		}
 	}

--- a/pkg/dependency/php_test.go
+++ b/pkg/dependency/php_test.go
@@ -1,14 +1,16 @@
 package dependency_test
 
 import (
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency"
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency/dependencyfakes"
+	"testing"
+	"time"
+
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
-	"time"
+
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency"
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency/dependencyfakes"
 )
 
 func TestPhp(t *testing.T) {
@@ -158,7 +160,7 @@ func testPhp(t *testing.T, when spec.G, it spec.S) {
 			expectedDepVersion := dependency.DepVersion{
 				Version:         "7.4.4",
 				URI:             "https://www.php.net/distributions/php-7.4.4.tar.gz",
-				SHA:             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				SHA256:          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				ReleaseDate:     &expectedReleaseDate,
 				DeprecationDate: &expectedDeprecationDate,
 				CPE:             "cpe:2.3:a:php:php:7.4.4:*:*:*:*:*:*:*",
@@ -170,8 +172,8 @@ func testPhp(t *testing.T, when spec.G, it spec.S) {
 			assert.Equal("https://www.php.net/releases/index.php?json&version=7.4.4", url)
 		})
 
-		when("the dependency has an MD5 instead of a SHA", func() {
-			it("validates the MD5 and calculates the SHA", func() {
+		when("the dependency has an MD5 instead of a SHA256", func() {
+			it("validates the MD5 and calculates the SHA256", func() {
 				fakeWebClient.GetReturns([]byte(`
 {
  "date": "19 Mar 2020",
@@ -195,7 +197,7 @@ func testPhp(t *testing.T, when spec.G, it spec.S) {
 				expectedDepVersion := dependency.DepVersion{
 					Version:         "7.4.4",
 					URI:             "https://www.php.net/distributions/php-7.4.4.tar.gz",
-					SHA:             "some-sha256",
+					SHA256:          "some-sha256",
 					ReleaseDate:     &expectedReleaseDate,
 					DeprecationDate: &expectedDeprecationDate,
 					CPE:             "cpe:2.3:a:php:php:7.4.4:*:*:*:*:*:*:*",
@@ -235,7 +237,7 @@ func testPhp(t *testing.T, when spec.G, it spec.S) {
 				expectedDepVersion := dependency.DepVersion{
 					Version:         "5.3.25",
 					URI:             "https://www.php.net/distributions/php-5.3.25.tar.gz",
-					SHA:             "some-sha256",
+					SHA256:          "some-sha256",
 					ReleaseDate:     &expectedReleaseDate,
 					DeprecationDate: &expectedDeprecationDate,
 					CPE:             "cpe:2.3:a:php:php:5.3.25:*:*:*:*:*:*:*",
@@ -269,7 +271,7 @@ func testPhp(t *testing.T, when spec.G, it spec.S) {
 				expectedDepVersion := dependency.DepVersion{
 					Version:         "5.1.6",
 					URI:             "https://www.php.net/distributions/php-5.1.6.tar.gz",
-					SHA:             "some-sha256",
+					SHA256:          "some-sha256",
 					ReleaseDate:     &expectedReleaseDate,
 					DeprecationDate: &expectedDeprecationDate,
 					CPE:             "cpe:2.3:a:php:php:5.1.6:*:*:*:*:*:*:*",

--- a/pkg/dependency/php_test.go
+++ b/pkg/dependency/php_test.go
@@ -153,12 +153,14 @@ func testPhp(t *testing.T, when spec.G, it spec.S) {
 			actualDepVersion, err := php.GetDependencyVersion("7.4.4")
 			require.NoError(err)
 
+			expectedReleaseDate := time.Date(2020, 03, 19, 0, 0, 0, 0, time.UTC)
+			expectedDeprecationDate := time.Date(2023, 03, 19, 0, 0, 0, 0, time.UTC)
 			expectedDepVersion := dependency.DepVersion{
 				Version:         "7.4.4",
 				URI:             "https://www.php.net/distributions/php-7.4.4.tar.gz",
 				SHA:             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-				ReleaseDate:     "2020-03-19T00:00:00Z",
-				DeprecationDate: "2023-03-19T00:00:00Z",
+				ReleaseDate:     &expectedReleaseDate,
+				DeprecationDate: &expectedDeprecationDate,
 				CPE:             "cpe:2.3:a:php:php:7.4.4:*:*:*:*:*:*:*",
 			}
 
@@ -188,12 +190,14 @@ func testPhp(t *testing.T, when spec.G, it spec.S) {
 				actualDepVersion, err := php.GetDependencyVersion("7.4.4")
 				require.NoError(err)
 
+				expectedReleaseDate := time.Date(2020, 03, 19, 0, 0, 0, 0, time.UTC)
+				expectedDeprecationDate := time.Date(2023, 03, 19, 0, 0, 0, 0, time.UTC)
 				expectedDepVersion := dependency.DepVersion{
 					Version:         "7.4.4",
 					URI:             "https://www.php.net/distributions/php-7.4.4.tar.gz",
 					SHA:             "some-sha256",
-					ReleaseDate:     "2020-03-19T00:00:00Z",
-					DeprecationDate: "2023-03-19T00:00:00Z",
+					ReleaseDate:     &expectedReleaseDate,
+					DeprecationDate: &expectedDeprecationDate,
 					CPE:             "cpe:2.3:a:php:php:7.4.4:*:*:*:*:*:*:*",
 				}
 				assert.Equal(expectedDepVersion, actualDepVersion)
@@ -226,12 +230,14 @@ func testPhp(t *testing.T, when spec.G, it spec.S) {
 				actualDepVersion, err := php.GetDependencyVersion("5.3.25")
 				require.NoError(err)
 
+				expectedReleaseDate := time.Date(2013, 05, 9, 0, 0, 0, 0, time.UTC)
+				expectedDeprecationDate := time.Date(2016, 05, 9, 0, 0, 0, 0, time.UTC)
 				expectedDepVersion := dependency.DepVersion{
 					Version:         "5.3.25",
 					URI:             "https://www.php.net/distributions/php-5.3.25.tar.gz",
 					SHA:             "some-sha256",
-					ReleaseDate:     "2013-05-09T00:00:00Z",
-					DeprecationDate: "2016-05-09T00:00:00Z",
+					ReleaseDate:     &expectedReleaseDate,
+					DeprecationDate: &expectedDeprecationDate,
 					CPE:             "cpe:2.3:a:php:php:5.3.25:*:*:*:*:*:*:*",
 				}
 				assert.Equal(expectedDepVersion, actualDepVersion)
@@ -258,12 +264,14 @@ func testPhp(t *testing.T, when spec.G, it spec.S) {
 				actualDepVersion, err := php.GetDependencyVersion("5.1.6")
 				require.NoError(err)
 
+				expectedReleaseDate := time.Date(2006, 8, 24, 0, 0, 0, 0, time.UTC)
+				expectedDeprecationDate := time.Date(2009, 8, 24, 0, 0, 0, 0, time.UTC)
 				expectedDepVersion := dependency.DepVersion{
 					Version:         "5.1.6",
 					URI:             "https://www.php.net/distributions/php-5.1.6.tar.gz",
 					SHA:             "some-sha256",
-					ReleaseDate:     "2006-08-24T00:00:00Z",
-					DeprecationDate: "2009-08-24T00:00:00Z",
+					ReleaseDate:     &expectedReleaseDate,
+					DeprecationDate: &expectedDeprecationDate,
 					CPE:             "cpe:2.3:a:php:php:5.1.6:*:*:*:*:*:*:*",
 				}
 				assert.Equal(expectedDepVersion, actualDepVersion)
@@ -315,7 +323,7 @@ func testPhp(t *testing.T, when spec.G, it spec.S) {
 				depVersion, err := php.GetDependencyVersion("7.4.4")
 				require.NoError(err)
 
-				assert.Equal("2020-03-01T00:00:00Z", depVersion.ReleaseDate)
+				assert.Equal("2020-03-01T00:00:00Z", depVersion.ReleaseDate.Format(time.RFC3339))
 			})
 		})
 
@@ -338,7 +346,7 @@ func testPhp(t *testing.T, when spec.G, it spec.S) {
 				depVersion, err := php.GetDependencyVersion("7.4.4")
 				require.NoError(err)
 
-				assert.Equal("2020-03-01T00:00:00Z", depVersion.ReleaseDate)
+				assert.Equal("2020-03-01T00:00:00Z", depVersion.ReleaseDate.Format(time.RFC3339))
 			})
 		})
 
@@ -361,7 +369,7 @@ func testPhp(t *testing.T, when spec.G, it spec.S) {
 				depVersion, err := php.GetDependencyVersion("7.4.4")
 				require.NoError(err)
 
-				assert.Equal("2020-03-01T00:00:00Z", depVersion.ReleaseDate)
+				assert.Equal("2020-03-01T00:00:00Z", depVersion.ReleaseDate.Format(time.RFC3339))
 			})
 		})
 

--- a/pkg/dependency/pypi.go
+++ b/pkg/dependency/pypi.go
@@ -58,23 +58,19 @@ func (p PyPi) GetDependencyVersion(version string) (DepVersion, error) {
 	return DepVersion{}, fmt.Errorf("could not find release with version %s: %w", version, err)
 }
 
-func (p PyPi) GetReleaseDate(version string) (time.Time, error) {
+func (p PyPi) GetReleaseDate(version string) (*time.Time, error) {
 	releases, err := p.getReleases()
 	if err != nil {
-		return time.Time{}, fmt.Errorf("could not get releases: %w", err)
+		return nil, fmt.Errorf("could not get releases: %w", err)
 	}
 
 	for _, release := range releases {
 		if release.Version == version {
-			releaseDate, err := time.Parse(time.RFC3339, release.ReleaseDate)
-			if err != nil {
-				return time.Time{}, fmt.Errorf("could not parse release date: %w", err)
-			}
-			return releaseDate, nil
+			return release.ReleaseDate, nil
 		}
 	}
 
-	return time.Time{}, fmt.Errorf("could not find release date for version %s", version)
+	return nil, fmt.Errorf("could not find release date for version %s", version)
 }
 
 func (p PyPi) getReleases() ([]DepVersion, error) {
@@ -124,7 +120,7 @@ func (p PyPi) getReleases() ([]DepVersion, error) {
 				Version:     version,
 				URI:         release.URL,
 				SHA:         release.Digests["sha256"],
-				ReleaseDate: uploadTime.Format(time.RFC3339),
+				ReleaseDate: &uploadTime,
 				CPE:         cpe,
 			})
 		}
@@ -136,8 +132,8 @@ func (p PyPi) getReleases() ([]DepVersion, error) {
 func (p PyPi) sortReleases(releases []DepVersion) error {
 	var sortErr error
 	sort.Slice(releases, func(i, j int) bool {
-		if releases[i].ReleaseDate != releases[j].ReleaseDate {
-			return releases[i].ReleaseDate > releases[j].ReleaseDate
+		if *releases[i].ReleaseDate != *releases[j].ReleaseDate {
+			return releases[i].ReleaseDate.After(*releases[j].ReleaseDate)
 		}
 
 		semver1, err := semver.NewVersion(releases[i].Version)

--- a/pkg/dependency/pypi.go
+++ b/pkg/dependency/pypi.go
@@ -3,10 +3,11 @@ package dependency
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/Masterminds/semver"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/Masterminds/semver"
 )
 
 type PyPi struct {
@@ -119,7 +120,7 @@ func (p PyPi) getReleases() ([]DepVersion, error) {
 			releases = append(releases, DepVersion{
 				Version:     version,
 				URI:         release.URL,
-				SHA:         release.Digests["sha256"],
+				SHA256:      release.Digests["sha256"],
 				ReleaseDate: &uploadTime,
 				CPE:         cpe,
 			})

--- a/pkg/dependency/pypi_test.go
+++ b/pkg/dependency/pypi_test.go
@@ -119,12 +119,13 @@ func testPyPi(t *testing.T, when spec.G, it spec.S) {
 			actualDep, err := pypi.GetDependencyVersion("2.0.0")
 			require.NoError(err)
 
+			expectedReleaseDate := time.Date(2010, 5, 1, 0, 0, 0, 0, time.UTC)
 			expectedDep := dependency.DepVersion{
 				Version:         "2.0.0",
 				URI:             "some-url",
 				SHA:             "some-sha256",
-				ReleaseDate:     "2010-05-01T00:00:00Z",
-				DeprecationDate: "",
+				ReleaseDate:     &expectedReleaseDate,
+				DeprecationDate: nil,
 				CPE:             "cpe:2.3:a:pypa:pip:2.0.0:*:*:*:*:python:*:*",
 			}
 			assert.Equal(expectedDep, actualDep)

--- a/pkg/dependency/pypi_test.go
+++ b/pkg/dependency/pypi_test.go
@@ -1,14 +1,16 @@
 package dependency_test
 
 import (
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency"
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency/dependencyfakes"
+	"testing"
+	"time"
+
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
-	"time"
+
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency"
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency/dependencyfakes"
 )
 
 func TestPyPi(t *testing.T) {
@@ -123,7 +125,7 @@ func testPyPi(t *testing.T, when spec.G, it spec.S) {
 			expectedDep := dependency.DepVersion{
 				Version:         "2.0.0",
 				URI:             "some-url",
-				SHA:             "some-sha256",
+				SHA256:          "some-sha256",
 				ReleaseDate:     &expectedReleaseDate,
 				DeprecationDate: nil,
 				CPE:             "cpe:2.3:a:pypa:pip:2.0.0:*:*:*:*:python:*:*",

--- a/pkg/dependency/python.go
+++ b/pkg/dependency/python.go
@@ -65,25 +65,25 @@ func (p Python) GetDependencyVersion(version string) (DepVersion, error) {
 		Version:         version,
 		URI:             sourceURI,
 		SHA:             sha256,
-		ReleaseDate:     releaseDate.Format(time.RFC3339),
+		ReleaseDate:     releaseDate,
 		DeprecationDate: deprecationDate,
 		CPE:             fmt.Sprintf("cpe:2.3:a:python:python:%s:*:*:*:*:*:*:*", version),
 	}, nil
 }
 
-func (p Python) GetReleaseDate(version string) (time.Time, error) {
+func (p Python) GetReleaseDate(version string) (*time.Time, error) {
 	_, releaseDate, _, err := p.getReleaseMetadata(version)
 	if err != nil {
-		return time.Time{}, fmt.Errorf("could not get release metadata: %w", err)
+		return nil, fmt.Errorf("could not get release metadata: %w", err)
 	}
 	return releaseDate, nil
 }
 
-func (p Python) getReleaseMetadata(version string) (string, time.Time, []string, error) {
+func (p Python) getReleaseMetadata(version string) (string, *time.Time, []string, error) {
 	versionWithoutPeriods := strings.ReplaceAll(version, ".", "")
 	body, err := p.webClient.Get(fmt.Sprintf("https://www.python.org/downloads/release/python-%s/", versionWithoutPeriods))
 	if err != nil {
-		return "", time.Time{}, nil, fmt.Errorf("could not get python downloads: %w", err)
+		return "", nil, nil, fmt.Errorf("could not get python downloads: %w", err)
 	}
 
 	releaseDateRegexp := regexp.MustCompile(`Release Date:</strong> ([\w]{3})[\w\.]* ([\d]+, [\d]+)`)
@@ -133,21 +133,21 @@ func (p Python) getReleaseMetadata(version string) (string, time.Time, []string,
 	}
 
 	if sourceURI == "" {
-		return "", time.Time{}, nil, errors.New("could not find source URI on download page")
+		return "", nil, nil, errors.New("could not find source URI on download page")
 	}
 	if len(potentialMD5s) == 0 {
-		return "", time.Time{}, nil, errors.New("could not find MD5 on download page")
+		return "", nil, nil, errors.New("could not find MD5 on download page")
 	}
 	if releaseDateDayAndYear == "" || releaseDateMonth == "" {
-		return "", time.Time{}, nil, errors.New("could not find release date on download page")
+		return "", nil, nil, errors.New("could not find release date on download page")
 	}
 
 	releaseDate, err := time.Parse("Jan 2, 2006", fmt.Sprintf("%s %s", releaseDateMonth, releaseDateDayAndYear))
 	if err != nil {
-		return "", time.Time{}, nil, fmt.Errorf("could not parse release date: %w", err)
+		return "", nil, nil, fmt.Errorf("could not parse release date: %w", err)
 	}
 
-	return sourceURI, releaseDate, potentialMD5s, nil
+	return sourceURI, &releaseDate, potentialMD5s, nil
 }
 
 func (p Python) getDependencySHA256(sourceURI string, potentialMD5s []string, version string) (string, error) {
@@ -186,10 +186,10 @@ func (p Python) getDependencySHA256(sourceURI string, potentialMD5s []string, ve
 	return sha256, nil
 }
 
-func (p Python) getReleaseDeprecationDate(version string) (string, error) {
+func (p Python) getReleaseDeprecationDate(version string) (*time.Time, error) {
 	body, err := p.webClient.Get("https://www.python.org/downloads/")
 	if err != nil {
-		return "", fmt.Errorf("could not get python downloads: %w", err)
+		return nil, fmt.Errorf("could not get python downloads: %w", err)
 	}
 
 	versionLine := strings.Join(strings.Split(version, ".")[0:2], ".")
@@ -203,10 +203,10 @@ func (p Python) getReleaseDeprecationDate(version string) (string, error) {
 			if len(matches) == 2 {
 				deprecationDate, err := time.Parse("2006-01-02", matches[1])
 				if err != nil {
-					return "", fmt.Errorf("could not parse deprecation date: %w", err)
+					return nil, fmt.Errorf("could not parse deprecation date: %w", err)
 				}
 
-				return deprecationDate.Format(time.RFC3339), nil
+				return &deprecationDate, nil
 			}
 
 			dateWithoutDayRegexp := regexp.MustCompile(`release-end">([\d]{4}-[\d]{2})`)
@@ -214,15 +214,15 @@ func (p Python) getReleaseDeprecationDate(version string) (string, error) {
 			if len(matches) == 2 {
 				deprecationDate, err := time.Parse("2006-01", matches[1])
 				if err != nil {
-					return "", fmt.Errorf("could not parse deprecation date: %w", err)
+					return nil, fmt.Errorf("could not parse deprecation date: %w", err)
 				}
 
-				return deprecationDate.Format(time.RFC3339), nil
+				return &deprecationDate, nil
 			}
 		}
 	}
 
-	return "", nil
+	return nil, nil
 }
 
 func (p Python) dependencyVersionHasWrongChecksum(version string) bool {

--- a/pkg/dependency/python.go
+++ b/pkg/dependency/python.go
@@ -64,7 +64,7 @@ func (p Python) GetDependencyVersion(version string) (DepVersion, error) {
 	return DepVersion{
 		Version:         version,
 		URI:             sourceURI,
-		SHA:             sha256,
+		SHA256:          sha256,
 		ReleaseDate:     releaseDate,
 		DeprecationDate: deprecationDate,
 		CPE:             fmt.Sprintf("cpe:2.3:a:python:python:%s:*:*:*:*:*:*:*", version),

--- a/pkg/dependency/python_test.go
+++ b/pkg/dependency/python_test.go
@@ -2,15 +2,17 @@ package dependency_test
 
 import (
 	"errors"
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency"
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency/dependencyfakes"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"strings"
-	"testing"
-	"time"
+
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency"
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency/dependencyfakes"
 )
 
 func TestPython(t *testing.T) {
@@ -79,7 +81,7 @@ func testPython(t *testing.T, when spec.G, it spec.S) {
 			expectedDepVersion := dependency.DepVersion{
 				Version:         "3.7.8",
 				URI:             "https://www.python.org/ftp/python/3.7.8/Python-3.7.8.tgz",
-				SHA:             "some-sha256",
+				SHA256:          "some-sha256",
 				ReleaseDate:     &expectedReleaseDate,
 				DeprecationDate: &expectedDeprecationDate,
 				CPE:             "cpe:2.3:a:python:python:3.7.8:*:*:*:*:*:*:*",
@@ -156,7 +158,7 @@ func testPython(t *testing.T, when spec.G, it spec.S) {
 				depVersion, err := python.GetDependencyVersion("3.3.3")
 				require.NoError(err)
 
-				assert.Equal("some-sha256", depVersion.SHA)
+				assert.Equal("some-sha256", depVersion.SHA256)
 
 				_, firstMD5 := fakeChecksummer.VerifyMD5ArgsForCall(0)
 				_, secondMD5 := fakeChecksummer.VerifyMD5ArgsForCall(1)
@@ -178,7 +180,7 @@ func testPython(t *testing.T, when spec.G, it spec.S) {
 				depVersion, err := python.GetDependencyVersion("2.5.5")
 				require.NoError(err)
 
-				assert.Equal("some-sha256", depVersion.SHA)
+				assert.Equal("some-sha256", depVersion.SHA256)
 
 				_, firstMD5 := fakeChecksummer.VerifyMD5ArgsForCall(0)
 				_, secondMD5 := fakeChecksummer.VerifyMD5ArgsForCall(1)
@@ -199,7 +201,7 @@ func testPython(t *testing.T, when spec.G, it spec.S) {
 				depVersion, err := python.GetDependencyVersion("3.1.0")
 				require.NoError(err)
 
-				assert.Equal("some-sha256", depVersion.SHA)
+				assert.Equal("some-sha256", depVersion.SHA256)
 
 				assert.Equal(0, fakeChecksummer.VerifyMD5CallCount())
 			})

--- a/pkg/dependency/python_test.go
+++ b/pkg/dependency/python_test.go
@@ -74,12 +74,14 @@ func testPython(t *testing.T, when spec.G, it spec.S) {
 			actualDepVersion, err := python.GetDependencyVersion("3.7.8")
 			require.NoError(err)
 
+			expectedReleaseDate := time.Date(2020, 6, 27, 0, 0, 0, 0, time.UTC)
+			expectedDeprecationDate := time.Date(2023, 6, 27, 0, 0, 0, 0, time.UTC)
 			expectedDepVersion := dependency.DepVersion{
 				Version:         "3.7.8",
 				URI:             "https://www.python.org/ftp/python/3.7.8/Python-3.7.8.tgz",
 				SHA:             "some-sha256",
-				ReleaseDate:     "2020-06-27T00:00:00Z",
-				DeprecationDate: "2023-06-27T00:00:00Z",
+				ReleaseDate:     &expectedReleaseDate,
+				DeprecationDate: &expectedDeprecationDate,
 				CPE:             "cpe:2.3:a:python:python:3.7.8:*:*:*:*:*:*:*",
 			}
 
@@ -101,7 +103,7 @@ func testPython(t *testing.T, when spec.G, it spec.S) {
 				depVersion, err := python.GetDependencyVersion("3.7.8")
 				require.NoError(err)
 
-				assert.Equal("2020-09-02T00:00:00Z", depVersion.ReleaseDate)
+				assert.Equal("2020-09-02T00:00:00Z", depVersion.ReleaseDate.Format(time.RFC3339))
 			})
 		})
 
@@ -114,7 +116,7 @@ func testPython(t *testing.T, when spec.G, it spec.S) {
 				depVersion, err := python.GetDependencyVersion("3.7.8")
 				require.NoError(err)
 
-				assert.Equal("2023-06-01T00:00:00Z", depVersion.DeprecationDate)
+				assert.Equal("2023-06-01T00:00:00Z", depVersion.DeprecationDate.Format(time.RFC3339))
 			})
 		})
 

--- a/pkg/dependency/ruby.go
+++ b/pkg/dependency/ruby.go
@@ -3,11 +3,13 @@ package dependency
 import (
 	"errors"
 	"fmt"
-	depErrors "github.com/paketo-buildpacks/dep-server/pkg/dependency/errors"
-	"gopkg.in/yaml.v2"
 	"regexp"
 	"strings"
 	"time"
+
+	"gopkg.in/yaml.v2"
+
+	depErrors "github.com/paketo-buildpacks/dep-server/pkg/dependency/errors"
 )
 
 type Ruby struct {
@@ -56,7 +58,7 @@ func (r Ruby) GetDependencyVersion(version string) (DepVersion, error) {
 			return DepVersion{
 				Version:         version,
 				URI:             depURL,
-				SHA:             depSHA,
+				SHA256:          depSHA,
 				ReleaseDate:     &releaseDate,
 				DeprecationDate: nil,
 				CPE:             fmt.Sprintf("cpe:2.3:a:ruby-lang:ruby:%s:*:*:*:*:*:*:*", version),
@@ -172,5 +174,5 @@ func (r Ruby) getDependencyURLAndSHAFromMirror(version string) (string, string, 
 		}
 	}
 
-	return "", "", fmt.Errorf("could not find URL and SHA for version %s", version)
+	return "", "", fmt.Errorf("could not find URL and SHA256 for version %s", version)
 }

--- a/pkg/dependency/ruby.go
+++ b/pkg/dependency/ruby.go
@@ -57,8 +57,8 @@ func (r Ruby) GetDependencyVersion(version string) (DepVersion, error) {
 				Version:         version,
 				URI:             depURL,
 				SHA:             depSHA,
-				ReleaseDate:     releaseDate.Format(time.RFC3339),
-				DeprecationDate: "",
+				ReleaseDate:     &releaseDate,
+				DeprecationDate: nil,
 				CPE:             fmt.Sprintf("cpe:2.3:a:ruby-lang:ruby:%s:*:*:*:*:*:*:*", version),
 			}, nil
 		}
@@ -67,23 +67,23 @@ func (r Ruby) GetDependencyVersion(version string) (DepVersion, error) {
 	return DepVersion{}, fmt.Errorf("could not find version %s", version)
 }
 
-func (r Ruby) GetReleaseDate(version string) (time.Time, error) {
+func (r Ruby) GetReleaseDate(version string) (*time.Time, error) {
 	rubyReleases, err := r.getAllReleases()
 	if err != nil {
-		return time.Time{}, fmt.Errorf("could not get releases: %w", err)
+		return nil, fmt.Errorf("could not get releases: %w", err)
 	}
 
 	for _, release := range rubyReleases {
 		if release.Version == version {
 			releaseDate, err := time.Parse("2006-01-02", release.Date)
 			if err != nil {
-				return time.Time{}, fmt.Errorf("could not parse release date: %w", err)
+				return nil, fmt.Errorf("could not parse release date: %w", err)
 			}
-			return releaseDate, nil
+			return &releaseDate, nil
 		}
 	}
 
-	return time.Time{}, fmt.Errorf("could not find release date for version %s", version)
+	return nil, fmt.Errorf("could not find release date for version %s", version)
 }
 
 func (r Ruby) getAllReleases() ([]RubyRelease, error) {

--- a/pkg/dependency/ruby_test.go
+++ b/pkg/dependency/ruby_test.go
@@ -1,14 +1,16 @@
 package dependency_test
 
 import (
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency"
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency/dependencyfakes"
+	"testing"
+	"time"
+
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
-	"time"
+
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency"
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency/dependencyfakes"
 )
 
 func TestRuby(t *testing.T) {
@@ -144,7 +146,7 @@ func testRuby(t *testing.T, when spec.G, it spec.S) {
 				expectedDepVersion := dependency.DepVersion{
 					Version:         "3.0.0",
 					URI:             "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.0.tar.gz",
-					SHA:             "some-sha-256-gz",
+					SHA256:          "some-sha-256-gz",
 					ReleaseDate:     &expectedReleaseDate,
 					DeprecationDate: nil,
 					CPE:             "cpe:2.3:a:ruby-lang:ruby:3.0.0:*:*:*:*:*:*:*",
@@ -159,7 +161,7 @@ func testRuby(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 
-		when("the version IS in the release yaml file but it does NOT have the URL and SHA", func() {
+		when("the version IS in the release yaml file but it does NOT have the URL and SHA256", func() {
 			it("check the index.txt file", func() {
 				fakeWebClient.GetReturnsOnCall(0, []byte(`
 <tr>
@@ -185,7 +187,7 @@ ruby-1.6.7	https://cache.ruby-lang.org/pub/ruby/1.6/ruby-1.6.7.tar.gz	some-sha-1
 				expectedDepVersion := dependency.DepVersion{
 					Version:         "1.6.7",
 					URI:             "https://cache.ruby-lang.org/pub/ruby/1.6/ruby-1.6.7.tar.gz",
-					SHA:             "some-sha-256",
+					SHA256:          "some-sha-256",
 					ReleaseDate:     &expectedReleaseDate,
 					DeprecationDate: nil,
 					CPE:             "cpe:2.3:a:ruby-lang:ruby:1.6.7:*:*:*:*:*:*:*",
@@ -249,7 +251,7 @@ ruby-2.7.1	https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.1.tar.gz	some-sha-1
 				expectedDepVersion := dependency.DepVersion{
 					Version:         "2.6.6",
 					URI:             "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.6.tar.gz",
-					SHA:             "some-sha-256-gz",
+					SHA256:          "some-sha-256-gz",
 					ReleaseDate:     &expectedReleaseDate,
 					DeprecationDate: nil,
 					CPE:             "cpe:2.3:a:ruby-lang:ruby:2.6.6:*:*:*:*:*:*:*",
@@ -322,7 +324,7 @@ ruby-1.9.0-0	https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.0-0.tar.gz	some-s
 					expectedDepVersion := dependency.DepVersion{
 						Version:         "1.9.0",
 						URI:             "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.0-0.tar.gz",
-						SHA:             "some-sha-256",
+						SHA256:          "some-sha-256",
 						ReleaseDate:     &expectedReleaseDate,
 						DeprecationDate: nil,
 						CPE:             "cpe:2.3:a:ruby-lang:ruby:1.9.0:*:*:*:*:*:*:*",
@@ -396,7 +398,7 @@ ruby-1.9.1-p0	https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p0.tar.gz	some
 					expectedDepVersion := dependency.DepVersion{
 						Version:         "1.9.1",
 						URI:             "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p0.tar.gz",
-						SHA:             "some-sha-256",
+						SHA256:          "some-sha-256",
 						ReleaseDate:     &expectedReleaseDate,
 						DeprecationDate: nil,
 						CPE:             "cpe:2.3:a:ruby-lang:ruby:1.9.1:*:*:*:*:*:*:*",

--- a/pkg/dependency/ruby_test.go
+++ b/pkg/dependency/ruby_test.go
@@ -140,12 +140,13 @@ func testRuby(t *testing.T, when spec.G, it spec.S) {
 				actualDepVersion, err := ruby.GetDependencyVersion("3.0.0")
 				require.NoError(err)
 
+				expectedReleaseDate := time.Date(2020, 12, 25, 0, 0, 0, 0, time.UTC)
 				expectedDepVersion := dependency.DepVersion{
 					Version:         "3.0.0",
 					URI:             "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.0.tar.gz",
 					SHA:             "some-sha-256-gz",
-					ReleaseDate:     "2020-12-25T00:00:00Z",
-					DeprecationDate: "",
+					ReleaseDate:     &expectedReleaseDate,
+					DeprecationDate: nil,
 					CPE:             "cpe:2.3:a:ruby-lang:ruby:3.0.0:*:*:*:*:*:*:*",
 				}
 				assert.Equal(expectedDepVersion, actualDepVersion)
@@ -180,12 +181,13 @@ ruby-1.6.7	https://cache.ruby-lang.org/pub/ruby/1.6/ruby-1.6.7.tar.gz	some-sha-1
 				actualDepVersion, err := ruby.GetDependencyVersion("1.6.7")
 				require.NoError(err)
 
+				expectedReleaseDate := time.Date(2002, 3, 1, 0, 0, 0, 0, time.UTC)
 				expectedDepVersion := dependency.DepVersion{
 					Version:         "1.6.7",
 					URI:             "https://cache.ruby-lang.org/pub/ruby/1.6/ruby-1.6.7.tar.gz",
 					SHA:             "some-sha-256",
-					ReleaseDate:     "2002-03-01T00:00:00Z",
-					DeprecationDate: "",
+					ReleaseDate:     &expectedReleaseDate,
+					DeprecationDate: nil,
 					CPE:             "cpe:2.3:a:ruby-lang:ruby:1.6.7:*:*:*:*:*:*:*",
 				}
 				assert.Equal(expectedDepVersion, actualDepVersion)
@@ -243,12 +245,13 @@ ruby-2.7.1	https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.1.tar.gz	some-sha-1
 				actualDepVersion, err := ruby.GetDependencyVersion("2.6.6")
 				require.NoError(err)
 
+				expectedReleaseDate := time.Date(2020, 4, 20, 0, 0, 0, 0, time.UTC)
 				expectedDepVersion := dependency.DepVersion{
 					Version:         "2.6.6",
 					URI:             "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.6.tar.gz",
 					SHA:             "some-sha-256-gz",
-					ReleaseDate:     "2020-04-20T00:00:00Z",
-					DeprecationDate: "",
+					ReleaseDate:     &expectedReleaseDate,
+					DeprecationDate: nil,
 					CPE:             "cpe:2.3:a:ruby-lang:ruby:2.6.6:*:*:*:*:*:*:*",
 				}
 				assert.Equal(expectedDepVersion, actualDepVersion)
@@ -315,12 +318,13 @@ ruby-1.9.0-0	https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.0-0.tar.gz	some-s
 					actualDepVersion, err := ruby.GetDependencyVersion("1.9.0")
 					require.NoError(err)
 
+					expectedReleaseDate := time.Date(2007, 12, 25, 0, 0, 0, 0, time.UTC)
 					expectedDepVersion := dependency.DepVersion{
 						Version:         "1.9.0",
 						URI:             "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.0-0.tar.gz",
 						SHA:             "some-sha-256",
-						ReleaseDate:     "2007-12-25T00:00:00Z",
-						DeprecationDate: "",
+						ReleaseDate:     &expectedReleaseDate,
+						DeprecationDate: nil,
 						CPE:             "cpe:2.3:a:ruby-lang:ruby:1.9.0:*:*:*:*:*:*:*",
 					}
 					assert.Equal(expectedDepVersion, actualDepVersion)
@@ -388,12 +392,13 @@ ruby-1.9.1-p0	https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p0.tar.gz	some
 					actualDepVersion, err := ruby.GetDependencyVersion("1.9.1")
 					require.NoError(err)
 
+					expectedReleaseDate := time.Date(2009, 1, 30, 0, 0, 0, 0, time.UTC)
 					expectedDepVersion := dependency.DepVersion{
 						Version:         "1.9.1",
 						URI:             "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p0.tar.gz",
 						SHA:             "some-sha-256",
-						ReleaseDate:     "2009-01-30T00:00:00Z",
-						DeprecationDate: "",
+						ReleaseDate:     &expectedReleaseDate,
+						DeprecationDate: nil,
 						CPE:             "cpe:2.3:a:ruby-lang:ruby:1.9.1:*:*:*:*:*:*:*",
 					}
 					assert.Equal(expectedDepVersion, actualDepVersion)

--- a/pkg/dependency/test/acceptance/acceptance_test.go
+++ b/pkg/dependency/test/acceptance/acceptance_test.go
@@ -82,7 +82,7 @@ func testAcceptance(t *testing.T, when spec.G, it spec.S) {
 						depVersions = append(depVersions, depVersion)
 
 						assert.Equal(version, depVersion.Version)
-						assert.Len(depVersion.SHA, 64, "SHA did not have 64 characters for %s %s", depName, version)
+						assert.Len(depVersion.SHA256, 64, "SHA256 did not have 64 characters for %s %s", depName, version)
 						assert.NotEmpty(depVersion.URI)
 
 						parsedVersion, err := semver.NewVersion(strings.TrimPrefix(version, "go"))

--- a/pkg/dependency/tini.go
+++ b/pkg/dependency/tini.go
@@ -46,23 +46,19 @@ func (t Tini) GetDependencyVersion(version string) (DepVersion, error) {
 	return DepVersion{}, fmt.Errorf("could not find tini version %s", version)
 }
 
-func (t Tini) GetReleaseDate(version string) (time.Time, error) {
+func (t Tini) GetReleaseDate(version string) (*time.Time, error) {
 	releases, err := t.githubClient.GetReleaseTags("krallin", "tini")
 	if err != nil {
-		return time.Time{}, fmt.Errorf("could not get releases: %w", err)
+		return nil, fmt.Errorf("could not get releases: %w", err)
 	}
 
 	for _, release := range releases {
 		if release.TagName == version {
-			releaseDate, err := time.Parse(time.RFC3339, release.PublishedDate)
-			if err != nil {
-				return time.Time{}, fmt.Errorf("could not parse release date: %w", err)
-			}
-			return releaseDate, nil
+			return &release.PublishedDate, nil
 		}
 	}
 
-	return time.Time{}, fmt.Errorf("could not find release date for version %s", version)
+	return nil, fmt.Errorf("could not find release date for version %s", version)
 }
 
 func (t Tini) createDependencyVersion(version string, release internal.GithubRelease) (DepVersion, error) {
@@ -88,8 +84,8 @@ func (t Tini) createDependencyVersion(version string, release internal.GithubRel
 		Version:         version,
 		URI:             tarballURL,
 		SHA:             dependencySHA,
-		ReleaseDate:     release.PublishedDate,
-		DeprecationDate: "",
+		ReleaseDate:     &release.PublishedDate,
+		DeprecationDate: nil,
 		CPE:             fmt.Sprintf("cpe:2.3:a:tini_project:tini:%s:*:*:*:*:*:*:*", strings.TrimPrefix(version, "v")),
 	}, nil
 }

--- a/pkg/dependency/tini.go
+++ b/pkg/dependency/tini.go
@@ -2,12 +2,13 @@ package dependency
 
 import (
 	"fmt"
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency/internal"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency/internal"
 )
 
 type Tini struct {
@@ -83,7 +84,7 @@ func (t Tini) createDependencyVersion(version string, release internal.GithubRel
 	return DepVersion{
 		Version:         version,
 		URI:             tarballURL,
-		SHA:             dependencySHA,
+		SHA256:          dependencySHA,
 		ReleaseDate:     &release.PublishedDate,
 		DeprecationDate: nil,
 		CPE:             fmt.Sprintf("cpe:2.3:a:tini_project:tini:%s:*:*:*:*:*:*:*", strings.TrimPrefix(version, "v")),

--- a/pkg/dependency/tini_test.go
+++ b/pkg/dependency/tini_test.go
@@ -1,15 +1,17 @@
 package dependency_test
 
 import (
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency"
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency/dependencyfakes"
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency/internal"
+	"testing"
+	"time"
+
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
-	"time"
+
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency"
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency/dependencyfakes"
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency/internal"
 )
 
 func TestTini(t *testing.T) {
@@ -89,7 +91,7 @@ func testTini(t *testing.T, when spec.G, it spec.S) {
 			expectedDep := dependency.DepVersion{
 				Version:         "v1.0.0",
 				URI:             "some-tarball-url",
-				SHA:             "some-source-sha",
+				SHA256:          "some-source-sha",
 				ReleaseDate:     &expectedReleaseDate,
 				DeprecationDate: nil,
 				CPE:             "cpe:2.3:a:tini_project:tini:1.0.0:*:*:*:*:*:*:*",

--- a/pkg/dependency/tini_test.go
+++ b/pkg/dependency/tini_test.go
@@ -39,19 +39,19 @@ func testTini(t *testing.T, when spec.G, it spec.S) {
 			fakeGithubClient.GetReleaseTagsReturns([]internal.GithubRelease{
 				{
 					TagName:       "v3.0.0",
-					PublishedDate: "2020-06-30T00:00:00Z",
+					PublishedDate: time.Date(2020, 6, 30, 0, 0, 0, 0, time.UTC),
 				},
 				{
 					TagName:       "v1.0.1",
-					PublishedDate: "2020-06-29T00:00:00Z",
+					PublishedDate: time.Date(2020, 6, 29, 0, 0, 0, 0, time.UTC),
 				},
 				{
 					TagName:       "v2.0.0",
-					PublishedDate: "2020-06-28T00:00:00Z",
+					PublishedDate: time.Date(2020, 6, 28, 0, 0, 0, 0, time.UTC),
 				},
 				{
 					TagName:       "v1.0.0",
-					PublishedDate: "2020-06-27T00:00:00Z",
+					PublishedDate: time.Date(2020, 6, 27, 0, 0, 0, 0, time.UTC),
 				},
 			}, nil)
 
@@ -72,11 +72,11 @@ func testTini(t *testing.T, when spec.G, it spec.S) {
 			fakeGithubClient.GetReleaseTagsReturns([]internal.GithubRelease{
 				{
 					TagName:       "v2.0.0",
-					PublishedDate: "2020-06-28T00:00:00Z",
+					PublishedDate: time.Date(2020, 6, 28, 0, 0, 0, 0, time.UTC),
 				},
 				{
 					TagName:       "v1.0.0",
-					PublishedDate: "2020-06-27T00:00:00Z",
+					PublishedDate: time.Date(2020, 6, 27, 0, 0, 0, 0, time.UTC),
 				},
 			}, nil)
 			fakeGithubClient.DownloadSourceTarballReturns("some-tarball-url", nil)
@@ -85,12 +85,13 @@ func testTini(t *testing.T, when spec.G, it spec.S) {
 			actualDep, err := tini.GetDependencyVersion("v1.0.0")
 			require.NoError(err)
 
+			expectedReleaseDate := time.Date(2020, 6, 27, 0, 0, 0, 0, time.UTC)
 			expectedDep := dependency.DepVersion{
 				Version:         "v1.0.0",
 				URI:             "some-tarball-url",
 				SHA:             "some-source-sha",
-				ReleaseDate:     "2020-06-27T00:00:00Z",
-				DeprecationDate: "",
+				ReleaseDate:     &expectedReleaseDate,
+				DeprecationDate: nil,
 				CPE:             "cpe:2.3:a:tini_project:tini:1.0.0:*:*:*:*:*:*:*",
 			}
 
@@ -108,11 +109,11 @@ func testTini(t *testing.T, when spec.G, it spec.S) {
 			fakeGithubClient.GetReleaseTagsReturns([]internal.GithubRelease{
 				{
 					TagName:       "v2.0.0",
-					PublishedDate: "2020-06-28T00:00:00Z",
+					PublishedDate: time.Date(2020, 6, 28, 0, 0, 0, 0, time.UTC),
 				},
 				{
 					TagName:       "v1.0.0",
-					PublishedDate: "2020-06-27T00:00:00Z",
+					PublishedDate: time.Date(2020, 6, 27, 0, 0, 0, 0, time.UTC),
 				},
 			}, nil)
 

--- a/pkg/dependency/yarn.go
+++ b/pkg/dependency/yarn.go
@@ -4,15 +4,17 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/Masterminds/semver"
-	depErrors "github.com/paketo-buildpacks/dep-server/pkg/dependency/errors"
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency/internal"
-	"github.com/paketo-buildpacks/dep-server/pkg/dependency/internal/internal_errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/Masterminds/semver"
+
+	depErrors "github.com/paketo-buildpacks/dep-server/pkg/dependency/errors"
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency/internal"
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency/internal/internal_errors"
 )
 
 type Yarn struct {
@@ -141,7 +143,7 @@ func (y Yarn) createDependencyVersion(version, tagName string, release internal.
 	return DepVersion{
 		Version:         version,
 		URI:             asset.BrowserDownloadUrl,
-		SHA:             dependencySHA,
+		SHA256:          dependencySHA,
 		ReleaseDate:     &release.PublishedDate,
 		DeprecationDate: nil,
 		CPE:             fmt.Sprintf("cpe:2.3:a:yarnpkg:yarn:%s:*:*:*:*:*:*:*", version),

--- a/pkg/dependency/yarn.go
+++ b/pkg/dependency/yarn.go
@@ -74,23 +74,19 @@ func (y Yarn) GetDependencyVersion(version string) (DepVersion, error) {
 	return DepVersion{}, fmt.Errorf("could not find yarn version %s", version)
 }
 
-func (y Yarn) GetReleaseDate(version string) (time.Time, error) {
+func (y Yarn) GetReleaseDate(version string) (*time.Time, error) {
 	releases, err := y.githubClient.GetReleaseTags("yarnpkg", "yarn")
 	if err != nil {
-		return time.Time{}, fmt.Errorf("could not get releases: %w", err)
+		return nil, fmt.Errorf("could not get releases: %w", err)
 	}
 
 	for _, release := range releases {
 		if release.TagName == version {
-			releaseDate, err := time.Parse(time.RFC3339, release.PublishedDate)
-			if err != nil {
-				return time.Time{}, fmt.Errorf("could not parse release date: %w", err)
-			}
-			return releaseDate, nil
+			return &release.PublishedDate, nil
 		}
 	}
 
-	return time.Time{}, fmt.Errorf("could not find release date for version %s", version)
+	return nil, fmt.Errorf("could not find release date for version %s", version)
 }
 
 func (y Yarn) createDependencyVersion(version, tagName string, release internal.GithubRelease) (DepVersion, error) {
@@ -146,8 +142,8 @@ func (y Yarn) createDependencyVersion(version, tagName string, release internal.
 		Version:         version,
 		URI:             asset.BrowserDownloadUrl,
 		SHA:             dependencySHA,
-		ReleaseDate:     release.PublishedDate,
-		DeprecationDate: "",
+		ReleaseDate:     &release.PublishedDate,
+		DeprecationDate: nil,
 		CPE:             fmt.Sprintf("cpe:2.3:a:yarnpkg:yarn:%s:*:*:*:*:*:*:*", version),
 	}, nil
 }

--- a/pkg/dependency/yarn_test.go
+++ b/pkg/dependency/yarn_test.go
@@ -46,23 +46,23 @@ func testYarn(t *testing.T, when spec.G, it spec.S) {
 			fakeGithubClient.GetReleaseTagsReturns([]internal.GithubRelease{
 				{
 					TagName:       "v3.0.0",
-					PublishedDate: "2020-06-30T00:00:00Z",
+					PublishedDate: time.Date(2020, 6, 30, 0, 0, 0, 0, time.UTC),
 				},
 				{
 					TagName:       "v1.0.1",
-					PublishedDate: "2020-06-29T00:00:00Z",
+					PublishedDate: time.Date(2020, 6, 29, 0, 0, 0, 0, time.UTC),
 				},
 				{
 					TagName:       "v2.0.0",
-					PublishedDate: "2020-06-28T00:00:00Z",
+					PublishedDate: time.Date(2020, 6, 28, 0, 0, 0, 0, time.UTC),
 				},
 				{
 					TagName:       "v2.0.0-exp.1",
-					PublishedDate: "2020-06-28T00:00:00Z",
+					PublishedDate: time.Date(2020, 6, 28, 0, 0, 0, 0, time.UTC),
 				},
 				{
 					TagName:       "v1.0.0",
-					PublishedDate: "2020-06-27T00:00:00Z",
+					PublishedDate: time.Date(2020, 6, 27, 0, 0, 0, 0, time.UTC),
 				},
 			}, nil)
 
@@ -83,11 +83,11 @@ func testYarn(t *testing.T, when spec.G, it spec.S) {
 			fakeGithubClient.GetReleaseTagsReturns([]internal.GithubRelease{
 				{
 					TagName:       "v2.0.0",
-					PublishedDate: "2020-06-28T00:00:00Z",
+					PublishedDate: time.Date(2020, 6, 28, 0, 0, 0, 0, time.UTC),
 				},
 				{
 					TagName:       "v1.0.0",
-					PublishedDate: "2020-06-27T00:00:00Z",
+					PublishedDate: time.Date(2020, 6, 27, 0, 0, 0, 0, time.UTC),
 				},
 			}, nil)
 			assetUrlContent := `{"browser_download_url":"some-source-url", "key":"some_value"}`
@@ -100,12 +100,13 @@ func testYarn(t *testing.T, when spec.G, it spec.S) {
 			actualDep, err := yarn.GetDependencyVersion("1.0.0")
 			require.NoError(err)
 
+			expectedReleaseDate := time.Date(2020, 6, 27, 0, 0, 0, 0, time.UTC)
 			expectedDep := dependency.DepVersion{
 				Version:         "1.0.0",
 				URI:             "some-source-url",
 				SHA:             "some-source-sha",
-				ReleaseDate:     "2020-06-27T00:00:00Z",
-				DeprecationDate: "",
+				ReleaseDate:     &expectedReleaseDate,
+				DeprecationDate: nil,
 				CPE:             "cpe:2.3:a:yarnpkg:yarn:1.0.0:*:*:*:*:*:*:*",
 			}
 
@@ -136,7 +137,7 @@ func testYarn(t *testing.T, when spec.G, it spec.S) {
 				fakeGithubClient.GetReleaseTagsReturns([]internal.GithubRelease{
 					{
 						TagName:       "v1.0.0",
-						PublishedDate: "2020-06-27T00:00:00Z",
+						PublishedDate: time.Date(2020, 6, 27, 0, 0, 0, 0, time.UTC),
 					},
 				}, nil)
 				assetUrlContent := `{"browser_download_url":"some-source-url", "key":"some_value"}`
@@ -157,11 +158,11 @@ func testYarn(t *testing.T, when spec.G, it spec.S) {
 			fakeGithubClient.GetReleaseTagsReturns([]internal.GithubRelease{
 				{
 					TagName:       "v2.0.0",
-					PublishedDate: "2020-06-28T00:00:00Z",
+					PublishedDate: time.Date(2020, 6, 28, 0, 0, 0, 0, time.UTC),
 				},
 				{
 					TagName:       "v1.0.0",
-					PublishedDate: "2020-06-27T00:00:00Z",
+					PublishedDate: time.Date(2020, 6, 27, 0, 0, 0, 0, time.UTC),
 				},
 			}, nil)
 

--- a/pkg/dependency/yarn_test.go
+++ b/pkg/dependency/yarn_test.go
@@ -2,17 +2,19 @@ package dependency_test
 
 import (
 	"errors"
+	"testing"
+	"time"
+
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/paketo-buildpacks/dep-server/pkg/dependency"
 	"github.com/paketo-buildpacks/dep-server/pkg/dependency/dependencyfakes"
 	depErrors "github.com/paketo-buildpacks/dep-server/pkg/dependency/errors"
 	"github.com/paketo-buildpacks/dep-server/pkg/dependency/internal"
 	"github.com/paketo-buildpacks/dep-server/pkg/dependency/internal/internal_errors"
-	"github.com/sclevine/spec"
-	"github.com/sclevine/spec/report"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"testing"
-	"time"
 )
 
 func TestYarn(t *testing.T) {
@@ -104,7 +106,7 @@ func testYarn(t *testing.T, when spec.G, it spec.S) {
 			expectedDep := dependency.DepVersion{
 				Version:         "1.0.0",
 				URI:             "some-source-url",
-				SHA:             "some-source-sha",
+				SHA256:          "some-source-sha",
 				ReleaseDate:     &expectedReleaseDate,
 				DeprecationDate: nil,
 				CPE:             "cpe:2.3:a:yarnpkg:yarn:1.0.0:*:*:*:*:*:*:*",


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Switches timestamps in the dependency library from strings to `*time.Time`
## Use Cases
This will ensure that our timestamps are consistent across all dependencies

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
