### PR TITLE
Get Rust tag commit instead of release

### DIFF
--- a/pkg/dependency/rust.go
+++ b/pkg/dependency/rust.go
@@ -63,12 +63,12 @@ func (r Rust) GetDependencyVersion(version string) (DepVersion, error) {
 }
 
 func (r Rust) GetReleaseDate(version string) (*time.Time, error) {
-	releaseDate, err := r.githubClient.GetReleaseDate("rust-lang", "rust", version)
+	tagCommit, err := r.githubClient.GetTagCommit("rust-lang", "rust", version)
 	if err != nil {
 		return nil, fmt.Errorf("could not get release date: %w", err)
 	}
 
-	return releaseDate, nil
+	return &tagCommit.Date, nil
 }
 
 func (r Rust) getDependencySHA(dependencyURL, version string) (string, error) {

--- a/pkg/dependency/rust_test.go
+++ b/pkg/dependency/rust_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/paketo-buildpacks/dep-server/pkg/dependency"
 	"github.com/paketo-buildpacks/dep-server/pkg/dependency/dependencyfakes"
+	"github.com/paketo-buildpacks/dep-server/pkg/dependency/internal"
 )
 
 func TestRust(t *testing.T) {
@@ -64,8 +65,13 @@ func testRust(t *testing.T, when spec.G, it spec.S) {
 
 	when("GetDependencyVersion", func() {
 		it("returns the correct rust version", func() {
-			releaseDate := time.Date(2020, 12, 31, 0, 0, 0, 0, time.UTC)
-			fakeGithubClient.GetReleaseDateReturns(&releaseDate, nil)
+			date := time.Date(2020, 12, 31, 0, 0, 0, 0, time.UTC)
+			tagCommit := internal.GithubTagCommit{
+				Tag:  "1.49.0",
+				SHA:  "some-sha",
+				Date: date,
+			}
+			fakeGithubClient.GetTagCommitReturns(tagCommit, nil)
 			fakeWebClient.GetReturnsOnCall(0, []byte("some-gpg-key"), nil)
 			fakeWebClient.GetReturnsOnCall(1, []byte("some-signature"), nil)
 			fakeChecksummer.GetSHA256Returns("some-source-sha", nil)
@@ -77,7 +83,7 @@ func testRust(t *testing.T, when spec.G, it spec.S) {
 				Version:         "1.49.0",
 				URI:             "https://static.rust-lang.org/dist/rustc-1.49.0-src.tar.gz",
 				SHA256:          "some-source-sha",
-				ReleaseDate:     &releaseDate,
+				ReleaseDate:     &tagCommit.Date,
 				DeprecationDate: nil,
 				CPE:             "cpe:2.3:a:rust-lang:rust:1.49.0:*:*:*:*:*:*:*",
 			}
@@ -99,9 +105,14 @@ func testRust(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	when("GetReleaseDate", func() {
-		it("returns the correct nginx release date", func() {
-			releaseDate := time.Date(2020, 12, 31, 0, 0, 0, 0, time.UTC)
-			fakeGithubClient.GetReleaseDateReturns(&releaseDate, nil)
+		it("returns the correct rust release date", func() {
+			date := time.Date(2020, 12, 31, 0, 0, 0, 0, time.UTC)
+			tagCommit := internal.GithubTagCommit{
+				Tag:  "1.49.0",
+				SHA:  "some-sha",
+				Date: date,
+			}
+			fakeGithubClient.GetTagCommitReturns(tagCommit, nil)
 
 			actualReleaseDate, err := rust.GetReleaseDate("1.49.0")
 			require.NoError(err)

--- a/pkg/dependency/test/acceptance/acceptance_test.go
+++ b/pkg/dependency/test/acceptance/acceptance_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Masterminds/semver"
 	"github.com/sclevine/spec"
@@ -99,8 +100,16 @@ func testAcceptance(t *testing.T, when spec.G, it spec.S) {
 					}
 
 					if depName != "CAAPM" {
-						for i := 0; i < len(depVersions)-1; i++ {
-							assert.True(depVersions[0].ReleaseDate.After(*depVersions[1].ReleaseDate) || depVersions[0].ReleaseDate.Equal(*depVersions[1].ReleaseDate))
+						if depName == "bundler" || depName == "composer" || depName == "nginx" {
+							for i := 0; i < len(depVersions)-1; i++ {
+								d := 24 * time.Hour
+								secondDay := depVersions[i+1].ReleaseDate.Truncate(d)
+								assert.True(depVersions[i].ReleaseDate.Truncate(d).After(secondDay) || depVersions[i].ReleaseDate.Truncate(d).Equal(secondDay))
+							}
+						} else {
+							for i := 0; i < len(depVersions)-1; i++ {
+								assert.True(depVersions[i].ReleaseDate.After(*depVersions[i+1].ReleaseDate) || depVersions[i].ReleaseDate.Equal(*depVersions[i+1].ReleaseDate), fmt.Sprintf("failed with %s and %s", depVersions[i], depVersions[i+1]))
+							}
 						}
 					}
 				})


### PR DESCRIPTION
Signed-off-by: Marty Spiewak <mspiewak@pivotal.io>

## Summary
<!-- A short explanation of the proposed change -->
Gets the tag commit for Rust in order to obtain the release date

## Use Cases
<!-- An explanation of the use cases your change enables -->
Allows the Build to succeed even when target an unofficial release.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
