### PR TITLE
All versions in dependency metadata should be semver-compliant

### DIFF
--- a/pkg/dependency/bundler.go
+++ b/pkg/dependency/bundler.go
@@ -53,6 +53,11 @@ func (b Bundler) GetDependencyVersion(version string) (DepVersion, error) {
 		return DepVersion{}, fmt.Errorf("could not get retrieve licenses: %w", err)
 	}
 
+	semVersion, err := convertToSemVer(version)
+	if err != nil {
+		return DepVersion{}, err
+	}
+
 	for _, release := range bundlerReleases {
 		if release.Version == version {
 			releaseDate, err := time.Parse(time.RFC3339Nano, release.Date)
@@ -60,7 +65,7 @@ func (b Bundler) GetDependencyVersion(version string) (DepVersion, error) {
 				return DepVersion{}, fmt.Errorf("could not parse release date: %w", err)
 			}
 			return DepVersion{
-				Version:         version,
+				Version:         semVersion,
 				URI:             depURL,
 				SHA256:          release.SHA,
 				ReleaseDate:     &releaseDate,

--- a/pkg/dependency/composer.go
+++ b/pkg/dependency/composer.go
@@ -85,8 +85,13 @@ func (c Composer) createDependencyVersion(release internal.GithubRelease) (DepVe
 		return DepVersion{}, fmt.Errorf("could not find license metadata: %w", err)
 	}
 
+	semVersion, err := convertToSemVer(release.TagName)
+	if err != nil {
+		return DepVersion{}, err
+	}
+
 	return DepVersion{
-		Version:         release.TagName,
+		Version:         semVersion,
 		URI:             depURL,
 		SHA256:          sha,
 		ReleaseDate:     &release.PublishedDate,

--- a/pkg/dependency/curl.go
+++ b/pkg/dependency/curl.go
@@ -130,8 +130,13 @@ func (c Curl) createDependencyVersion(release CurlRelease) (DepVersion, error) {
 	depURL := c.dependencyURL(release)
 	licenses, err := c.licenseRetriever.LookupLicenses("curl", depURL)
 
+	semVersion, err := convertToSemVer(release.Version)
+	if err != nil {
+		return DepVersion{}, err
+	}
+
 	return DepVersion{
-		Version:     release.Version,
+		Version:     semVersion,
 		URI:         depURL,
 		SHA256:      sha,
 		ReleaseDate: &release.Date,

--- a/pkg/dependency/curl_test.go
+++ b/pkg/dependency/curl_test.go
@@ -46,6 +46,7 @@ func testCurl(t *testing.T, when spec.G, it spec.S) {
 2;7.72.0;3;2020-08-19;3 months;49;161;100;342;3;13;
 3;7.71.1;4;2020-07-01;5 months;7;168;18;360;0;13;
 4;7.71.0;4;2020-06-24;5 months;56;224;136;496;4;17;
+5;7.8;5;2020-06-24;5 months;56;224;136;496;4;17;
 `), nil)
 
 			versions, err := curl.GetAllVersionRefs()
@@ -57,6 +58,7 @@ func testCurl(t *testing.T, when spec.G, it spec.S) {
 				"7.72.0",
 				"7.71.1",
 				"7.71.0",
+				"7.8",
 			}, versions)
 
 			urlArg, _ := fakeWebClient.GetArgsForCall(0)
@@ -111,6 +113,42 @@ func testCurl(t *testing.T, when spec.G, it spec.S) {
 			releaseAssetSignatureArg, _, curlGPGKeyArg := fakeChecksummer.VerifyASCArgsForCall(0)
 			assert.Equal("some-signature", releaseAssetSignatureArg)
 			assert.Equal([]string{"some-gpg-key"}, curlGPGKeyArg)
+		})
+
+		when("the version is not semveric", func() {
+			it("returns the correct curl version", func() {
+				fakeWebClient.GetReturnsOnCall(0, []byte(`
+0;7.74.0;0;2020-12-09;0;56;56;107;107;1;1;
+1;7.73.0;3;2020-10-14;56 days;56;112;135;242;9;10;
+2;7.72.0;3;2020-08-19;3 months;49;161;100;342;3;13;
+3;7.8;4;2020-10-14;56 days;56;112;135;242;9;10;
+`), nil)
+				fakeWebClient.GetReturnsOnCall(1, []byte("some-gpg-key"), nil)
+				fakeWebClient.GetReturnsOnCall(2, []byte("some-signature"), nil)
+				fakeChecksummer.GetSHA256Returns("some-source-sha", nil)
+				fakeLicenseRetriever.LookupLicensesReturns([]string{"MIT", "MIT-2"}, nil)
+				fakePURLGenerator.GenerateReturns("pkg:generic/curl@7.8?checksum=some-source-sha&download_url=https://curl.se")
+
+				actualDep, err := curl.GetDependencyVersion("7.8")
+				require.NoError(err)
+
+				assert.Equal(1, fakeLicenseRetriever.LookupLicensesCallCount())
+				assert.Equal(1, fakePURLGenerator.GenerateCallCount())
+
+				expectedReleaseDate := time.Date(2020, 10, 14, 0, 0, 0, 0, time.UTC)
+				expectedDep := dependency.DepVersion{
+					Version:     "7.8.0",
+					URI:         "https://curl.se/download/archeology/curl-7.8.tar.gz",
+					SHA256:      "some-source-sha",
+					ReleaseDate: &expectedReleaseDate,
+					CPE:         "cpe:2.3:a:haxx:curl:7.8:*:*:*:*:*:*:*",
+					PURL:        "pkg:generic/curl@7.8?checksum=some-source-sha&download_url=https://curl.se",
+					Licenses:    []string{"MIT", "MIT-2"},
+				}
+
+				assert.Equal(expectedDep, actualDep)
+				assert.Equal(0, fakeChecksummer.VerifyASCCallCount())
+			})
 		})
 
 		when("the version is older then 7.3.30", func() {

--- a/pkg/dependency/dep_factory.go
+++ b/pkg/dependency/dep_factory.go
@@ -2,8 +2,10 @@ package dependency
 
 import (
 	"fmt"
+	"regexp"
 	"time"
 
+	"github.com/Masterminds/semver"
 	"github.com/paketo-buildpacks/dep-server/pkg/dependency/internal"
 	"github.com/paketo-buildpacks/dep-server/pkg/dependency/licenses"
 	"github.com/paketo-buildpacks/dep-server/pkg/dependency/purl"
@@ -116,6 +118,22 @@ func (d DepFactory) SupportsDependency(name string) bool {
 	}
 
 	return true
+}
+
+// Strip the any non-digit prefix off the version and ensure that the new
+// version is semver-compatible
+func convertToSemVer(version string) (string, error) {
+	reg, err := regexp.Compile(`([0-9]+.?)+`)
+	if err != nil {
+		return "", err
+	}
+
+	semanticVersion, err := semver.NewVersion(reg.FindAllString(version, 1)[0])
+	if err != nil {
+		return "", err
+	}
+
+	return semanticVersion.String(), nil
 }
 
 func (d DepFactory) NewDependency(name string) (Dependency, error) {

--- a/pkg/dependency/dotnet.go
+++ b/pkg/dependency/dotnet.go
@@ -132,8 +132,13 @@ func (d dotnet) GetDependencyVersion(version string) (DepVersion, error) {
 		return DepVersion{}, fmt.Errorf("could not get licenses: %w", err)
 	}
 
+	semVersion, err := convertToSemVer(version)
+	if err != nil {
+		return DepVersion{}, err
+	}
+
 	depVersion := DepVersion{
-		Version:     version,
+		Version:     semVersion,
 		URI:         releaseFile.URL,
 		SHA256:      sha256,
 		ReleaseDate: releaseDate,

--- a/pkg/dependency/go.go
+++ b/pkg/dependency/go.go
@@ -82,7 +82,7 @@ func (g Go) GetDependencyVersion(version string) (DepVersion, error) {
 
 	licenses, err := g.licenseRetriever.LookupLicenses("go", depURL)
 	if err != nil {
-		return DepVersion{}, fmt.Errorf("could not convert to SemVer: %w", err)
+		return DepVersion{}, fmt.Errorf("could not get retrieve licenses: %w", err)
 	}
 
 	semVersion, err := convertToSemVer(version)

--- a/pkg/dependency/go_test.go
+++ b/pkg/dependency/go_test.go
@@ -159,7 +159,7 @@ func testGo(t *testing.T, when spec.G, it spec.S) {
 			assert.Equal(1, fakeLicenseRetriever.LookupLicensesCallCount())
 			assert.Equal(1, fakePURLGenerator.GenerateCallCount())
 			expectedDep := dependency.DepVersion{
-				Version:         "go1.13.9",
+				Version:         "1.13.9",
 				URI:             "https://dl.google.com/go/go1.13.9.src.tar.gz",
 				SHA256:          "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
 				ReleaseDate:     &expectedReleaseDate,
@@ -204,7 +204,7 @@ func testGo(t *testing.T, when spec.G, it spec.S) {
 				assert.Equal(1, fakeLicenseRetriever.LookupLicensesCallCount())
 				assert.Equal(1, fakePURLGenerator.GenerateCallCount())
 				expectedDep := dependency.DepVersion{
-					Version:         "go1.13.9",
+					Version:         "1.13.9",
 					URI:             "https://dl.google.com/go/go1.13.9.src.tar.gz",
 					SHA256:          "some-source-sha",
 					ReleaseDate:     &expectedReleaseDate,
@@ -220,6 +220,54 @@ func testGo(t *testing.T, when spec.G, it spec.S) {
 
 				urlArg, dependencyPathDownloadArg, _ := fakeWebClient.DownloadArgsForCall(0)
 				assert.Equal("https://dl.google.com/go/go1.13.9.src.tar.gz", urlArg)
+
+				assert.Equal(dependencyPathDownloadArg, fakeChecksummer.GetSHA256ArgsForCall(0))
+			})
+		})
+
+		when("the version passed in is already semver", func() {
+			it("returns the right go version", func() {
+				fakeWebClient.GetReturnsOnCall(0, []byte(`
+[
+{"version": "go1.13", "files": [{"sha256": "", "kind": "source"}]}
+]`), nil)
+
+				fakeWebClient.GetReturnsOnCall(1, []byte(`
+<!DOCTYPE html>
+<html lang="en">
+	<h2 id="go1.13">go1.13 (released 2020-03-19)</h2>
+		<p>
+		go1.13
+		(released 2020-03-19)
+		</p>
+`), nil)
+
+				fakeChecksummer.GetSHA256Returns("some-source-sha", nil)
+				fakeLicenseRetriever.LookupLicensesReturns([]string{"MIT", "MIT-2"}, nil)
+				fakePURLGenerator.GenerateReturns("pkg:generic/go@go1.13?checksum=some-source-sha&download_url=https://dl.google.com/go")
+
+				actualDep, err := golang.GetDependencyVersion("1.13.0")
+				require.NoError(err)
+
+				assert.Equal(1, fakeLicenseRetriever.LookupLicensesCallCount())
+				assert.Equal(1, fakePURLGenerator.GenerateCallCount())
+				expectedDep := dependency.DepVersion{
+					Version:         "1.13.0",
+					URI:             "https://dl.google.com/go/go1.13.src.tar.gz",
+					SHA256:          "some-source-sha",
+					ReleaseDate:     &expectedReleaseDate,
+					DeprecationDate: nil,
+					CPE:             "cpe:2.3:a:golang:go:1.13:*:*:*:*:*:*:*",
+					PURL:            "pkg:generic/go@go1.13?checksum=some-source-sha&download_url=https://dl.google.com/go",
+					Licenses:        []string{"MIT", "MIT-2"},
+				}
+				assert.Equal(expectedDep, actualDep)
+
+				urlArg, _ := fakeWebClient.GetArgsForCall(0)
+				assert.Equal("https://golang.org/dl/?mode=json&include=all", urlArg)
+
+				urlArg, dependencyPathDownloadArg, _ := fakeWebClient.DownloadArgsForCall(0)
+				assert.Equal("https://dl.google.com/go/go1.13.src.tar.gz", urlArg)
 
 				assert.Equal(dependencyPathDownloadArg, fakeChecksummer.GetSHA256ArgsForCall(0))
 			})
@@ -260,7 +308,7 @@ func testGo(t *testing.T, when spec.G, it spec.S) {
 		go1.14.1
 		(released 2020/03/19)
 		</p>
-	<h2 id="go1.13">go1.13 (released 2019-09/03)</h2>
+	<h2 id="go1.13">go1.13 (released 2019-09-03)</h2>
 		<p>
 		go1.13.1
 		(released 2019-09-25)

--- a/pkg/dependency/httpd.go
+++ b/pkg/dependency/httpd.go
@@ -67,8 +67,13 @@ func (h Httpd) GetDependencyVersion(version string) (DepVersion, error) {
 		return DepVersion{}, fmt.Errorf("could not get retrieve licenses: %w", err)
 	}
 
+	semVersion, err := convertToSemVer(version)
+	if err != nil {
+		return DepVersion{}, err
+	}
+
 	return DepVersion{
-		Version:     version,
+		Version:     semVersion,
 		URI:         depURL,
 		SHA256:      sha,
 		ReleaseDate: &release.releaseDate,

--- a/pkg/dependency/nginx.go
+++ b/pkg/dependency/nginx.go
@@ -49,8 +49,13 @@ func (n Nginx) GetDependencyVersion(version string) (DepVersion, error) {
 		return DepVersion{}, fmt.Errorf("could not get retrieve licenses: %w", err)
 	}
 
+	semVersion, err := convertToSemVer(version)
+	if err != nil {
+		return DepVersion{}, err
+	}
+
 	return DepVersion{
-		Version:         version,
+		Version:         semVersion,
 		URI:             dependencyURL,
 		SHA256:          sha,
 		ReleaseDate:     &tagCommit.Date,

--- a/pkg/dependency/node.go
+++ b/pkg/dependency/node.go
@@ -44,6 +44,10 @@ func (n Node) GetAllVersionRefs() ([]string, error) {
 }
 
 func (n Node) GetDependencyVersion(version string) (DepVersion, error) {
+	// We expect an official Node version (ex. v13.6.1) to be passed in.
+	// Safeguard against user passing in a non-official semveric version (ex. 13.6.1)
+	version = convertToNodeVersion(version)
+
 	nodeReleases, err := n.getAllReleases()
 	if err != nil {
 		return DepVersion{}, fmt.Errorf("could not get releases: %w", err)
@@ -118,8 +122,13 @@ func (n Node) createDepVersion(release NodeRelease, releaseSchedule ReleaseSched
 		return DepVersion{}, fmt.Errorf("could not get retrieve licenses: %w", err)
 	}
 
+	semVersion, err := convertToSemVer(release.Version)
+	if err != nil {
+		return DepVersion{}, err
+	}
+
 	return DepVersion{
-		Version:         release.Version,
+		Version:         semVersion,
 		URI:             depURL,
 		SHA256:          sha,
 		ReleaseDate:     &releaseDate,
@@ -189,4 +198,15 @@ func (n Node) dependencyURL(version string) string {
 
 func (n Node) shaFileURL(version string) string {
 	return fmt.Sprintf("https://nodejs.org/dist/%s/SHASUMS256.txt", version)
+}
+
+// If a user passes in the semantic version rather than the Node vX.X.X version
+// The GetDependencyVersion function will fail since we can't easily query the
+// Go release pages
+func convertToNodeVersion(version string) string {
+	// add a `v` prefix
+	if !strings.Contains(version, "v") {
+		version = "v" + version
+	}
+	return version
 }

--- a/pkg/dependency/pecl.go
+++ b/pkg/dependency/pecl.go
@@ -70,9 +70,13 @@ func (p Pecl) GetDependencyVersion(version string) (DepVersion, error) {
 			if err != nil {
 				return DepVersion{}, fmt.Errorf("could not get retrieve licenses: %w", err)
 			}
+			semVersion, err := convertToSemVer(currVersion.Version)
+			if err != nil {
+				return DepVersion{}, err
+			}
 
 			return DepVersion{
-				Version:         currVersion.Version,
+				Version:         semVersion,
 				URI:             dependencyURL,
 				SHA256:          dependencySHA,
 				ReleaseDate:     currVersion.ReleaseDate,

--- a/pkg/dependency/php.go
+++ b/pkg/dependency/php.go
@@ -81,8 +81,13 @@ func (p Php) GetDependencyVersion(version string) (DepVersion, error) {
 		return DepVersion{}, fmt.Errorf("could not get retrieve licenses: %w", err)
 	}
 
+	semVersion, err := convertToSemVer(version)
+	if err != nil {
+		return DepVersion{}, err
+	}
+
 	return DepVersion{
-		Version:         version,
+		Version:         semVersion,
 		URI:             dependencyURL,
 		SHA256:          dependencySHA,
 		ReleaseDate:     releaseDate,

--- a/pkg/dependency/pypi_test.go
+++ b/pkg/dependency/pypi_test.go
@@ -77,6 +77,10 @@ func testPyPi(t *testing.T, when spec.G, it spec.S) {
   "2.1.0": [
     {"packagetype": "sdist", "upload_time_iso_8601": "2010-08-01T00:00:00.000000Z", "digests": {"sha256": "some-sha256"}},
     {"packagetype": "bdist_wheel", "upload_time_iso_8601": "2010-08-01T00:00:00.000000Z"}
+  ],
+  "1.1": [
+    {"packagetype": "sdist", "upload_time_iso_8601": "2010-08-01T00:00:00.000000Z", "digests": {"sha256": "some-sha256"}},
+    {"packagetype": "bdist_wheel", "upload_time_iso_8601": "2010-08-01T00:00:00.000000Z"}
   ]
 }}`), nil)
 			versions, err := pypi.GetAllVersionRefs()
@@ -86,6 +90,7 @@ func testPyPi(t *testing.T, when spec.G, it spec.S) {
 			assert.Equal([]string{
 				"2.1.0",
 				"1.20.0",
+				"1.1.0",
 				"2.0.0",
 				"1.10.0",
 				"1.2.0",
@@ -105,7 +110,7 @@ func testPyPi(t *testing.T, when spec.G, it spec.S) {
   "1.0.0": [
     {"packagetype": "sdist", "upload_time_iso_8601": "2010-01-01T00:00:00.000000Z", "digests": {"sha256": "some-sha256"}}
   ],
-  "2.0.0": [
+  "21.2": [
     {"packagetype": "bdist_wheel", "upload_time_iso_8601": "2010-05-01T00:00:00.000000Z"},
     {
       "packagetype": "sdist",
@@ -123,28 +128,79 @@ func testPyPi(t *testing.T, when spec.G, it spec.S) {
 }}`), nil)
 
 			fakeLicenseRetriever.LookupLicensesReturns([]string{"MIT", "MIT-2"}, nil)
-			fakePURLGenerator.GenerateReturns("pkg:generic/pip@2.0.0?checksum=some-sha-256gz&download_url=some-url")
+			fakePURLGenerator.GenerateReturns("pkg:generic/pip@21.2?checksum=some-sha-256gz&download_url=some-url")
 
-			actualDep, err := pypi.GetDependencyVersion("2.0.0")
+			actualDep, err := pypi.GetDependencyVersion("21.2")
 			require.NoError(err)
 
 			assert.Equal(3, fakeLicenseRetriever.LookupLicensesCallCount())
 			assert.Equal(3, fakePURLGenerator.GenerateCallCount())
 			expectedReleaseDate := time.Date(2010, 5, 1, 0, 0, 0, 0, time.UTC)
 			expectedDep := dependency.DepVersion{
-				Version:         "2.0.0",
+				Version:         "21.2.0",
 				URI:             "some-url",
 				SHA256:          "some-sha256",
 				ReleaseDate:     &expectedReleaseDate,
 				DeprecationDate: nil,
-				CPE:             "cpe:2.3:a:pypa:pip:2.0.0:*:*:*:*:python:*:*",
-				PURL:            "pkg:generic/pip@2.0.0?checksum=some-sha-256gz&download_url=some-url",
+				CPE:             "cpe:2.3:a:pypa:pip:21.2:*:*:*:*:python:*:*",
+				PURL:            "pkg:generic/pip@21.2?checksum=some-sha-256gz&download_url=some-url",
 				Licenses:        []string{"MIT", "MIT-2"},
 			}
 			assert.Equal(expectedDep, actualDep)
 
 			urlArg, _ := fakeWebClient.GetArgsForCall(0)
 			assert.Equal("https://pypi.org/pypi/pip/json", urlArg)
+		})
+
+		when("a non-official semveric version is passed in", func() {
+			it("returns the correct version", func() {
+				fakeWebClient.GetReturns([]byte(`{
+"releases": {
+  "1.0.0": [
+    {"packagetype": "sdist", "upload_time_iso_8601": "2010-01-01T00:00:00.000000Z", "digests": {"sha256": "some-sha256"}}
+  ],
+  "21.2": [
+    {"packagetype": "bdist_wheel", "upload_time_iso_8601": "2010-05-01T00:00:00.000000Z"},
+    {
+      "packagetype": "sdist",
+      "upload_time_iso_8601": "2010-05-01T00:00:00.000000Z",
+      "digests": {
+        "md5": "some-md5",
+        "sha256": "some-sha256"
+      },
+      "url": "some-url"
+    }
+  ],
+  "3.0.0": [
+    {"packagetype": "sdist", "upload_time_iso_8601": "2010-08-01T00:00:00.000000Z", "digests": {"sha256": "some-sha256"}}
+  ]
+}}`), nil)
+
+				fakeLicenseRetriever.LookupLicensesReturns([]string{"MIT", "MIT-2"}, nil)
+				fakePURLGenerator.GenerateReturns("pkg:generic/pip@21.2?checksum=some-sha-256gz&download_url=some-url")
+
+				actualDep, err := pypi.GetDependencyVersion("21.2.0")
+				require.NoError(err)
+
+				assert.Equal(3, fakeLicenseRetriever.LookupLicensesCallCount())
+				assert.Equal(3, fakePURLGenerator.GenerateCallCount())
+				expectedReleaseDate := time.Date(2010, 5, 1, 0, 0, 0, 0, time.UTC)
+				expectedDep := dependency.DepVersion{
+					Version:         "21.2.0",
+					URI:             "some-url",
+					SHA256:          "some-sha256",
+					ReleaseDate:     &expectedReleaseDate,
+					DeprecationDate: nil,
+					CPE:             "cpe:2.3:a:pypa:pip:21.2:*:*:*:*:python:*:*",
+					PURL:            "pkg:generic/pip@21.2?checksum=some-sha-256gz&download_url=some-url",
+					Licenses:        []string{"MIT", "MIT-2"},
+				}
+				assert.Equal(expectedDep, actualDep)
+
+				urlArg, _ := fakeWebClient.GetArgsForCall(0)
+				assert.Equal("https://pypi.org/pypi/pip/json", urlArg)
+			})
+
 		})
 
 		when("the product is not pip", func() {

--- a/pkg/dependency/python.go
+++ b/pkg/dependency/python.go
@@ -59,8 +59,13 @@ func (p Python) GetDependencyVersion(version string) (DepVersion, error) {
 		return DepVersion{}, fmt.Errorf("could not get retrieve licenses: %w", err)
 	}
 
+	semVersion, err := convertToSemVer(version)
+	if err != nil {
+		return DepVersion{}, err
+	}
+
 	return DepVersion{
-		Version:         version,
+		Version:         semVersion,
 		URI:             sourceURI,
 		SHA256:          sha256,
 		ReleaseDate:     releaseDate,

--- a/pkg/dependency/ruby.go
+++ b/pkg/dependency/ruby.go
@@ -61,9 +61,13 @@ func (r Ruby) GetDependencyVersion(version string) (DepVersion, error) {
 			if err != nil {
 				return DepVersion{}, fmt.Errorf("could not parse release date: %w", err)
 			}
+			semVersion, err := convertToSemVer(version)
+			if err != nil {
+				return DepVersion{}, err
+			}
 
 			return DepVersion{
-				Version:         version,
+				Version:         semVersion,
 				URI:             depURL,
 				SHA256:          depSHA,
 				ReleaseDate:     &releaseDate,

--- a/pkg/dependency/rust.go
+++ b/pkg/dependency/rust.go
@@ -59,8 +59,13 @@ func (r Rust) GetDependencyVersion(version string) (DepVersion, error) {
 		return DepVersion{}, fmt.Errorf("could not get retrieve licenses: %w", err)
 	}
 
+	semVersion, err := convertToSemVer(version)
+	if err != nil {
+		return DepVersion{}, err
+	}
+
 	return DepVersion{
-		Version:         version,
+		Version:         semVersion,
 		URI:             dependencyURL,
 		SHA256:          sha,
 		ReleaseDate:     releaseDate,

--- a/pkg/dependency/test/acceptance/acceptance_test.go
+++ b/pkg/dependency/test/acceptance/acceptance_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -83,7 +84,17 @@ func testAcceptance(t *testing.T, when spec.G, it spec.S) {
 
 						depVersions = append(depVersions, depVersion)
 
-						assert.Equal(version, depVersion.Version)
+						// some versions from GetAllVersionRefs are not semver compatible
+						// but the depVersion version is.
+						// To check theyre equivalent versions: chop off any leading
+						// non-digit or period characters and convert to semVer
+						reg, err := regexp.Compile(`([0-9]+.?)+`)
+						require.NoError(err)
+						semVersion, err := semver.NewVersion(reg.FindAllString(version, 1)[0])
+						require.NoError(err, "Invalid Semantic Version")
+
+						assert.Equal(semVersion.String(), depVersion.Version)
+
 						assert.Len(depVersion.SHA256, 64, "SHA256 did not have 64 characters for %s %s", depName, version)
 						assert.NotEmpty(depVersion.URI)
 

--- a/pkg/dependency/tini.go
+++ b/pkg/dependency/tini.go
@@ -38,6 +38,10 @@ func (t Tini) GetDependencyVersion(version string) (DepVersion, error) {
 	}
 
 	for _, release := range releases {
+		// We expect an official Tini version (ex. vX.X.X) to be passed in.
+		// Safeguard against user passing in a non-official semveric version
+		version = convertToTiniVersion(version)
+
 		if release.TagName == version {
 			depVersion, err := t.createDependencyVersion(version, release)
 			if err != nil {
@@ -65,6 +69,11 @@ func (t Tini) GetReleaseDate(version string) (*time.Time, error) {
 }
 
 func (t Tini) createDependencyVersion(version string, release internal.GithubRelease) (DepVersion, error) {
+	// this function receives an official Tini version from
+	// GetAllDependencies usually, but if a user passes in a semantic version
+	// via a workflow this will convert the version to an official Tini version.
+	version = convertToTiniVersion(version)
+
 	tarballDir, err := ioutil.TempDir("", "tini")
 	if err != nil {
 		return DepVersion{}, fmt.Errorf("could not create temp directory: %w", err)
@@ -88,8 +97,13 @@ func (t Tini) createDependencyVersion(version string, release internal.GithubRel
 		return DepVersion{}, fmt.Errorf("could not get retrieve licenses: %w", err)
 	}
 
+	semVersion, err := convertToSemVer(version)
+	if err != nil {
+		return DepVersion{}, err
+	}
+
 	return DepVersion{
-		Version:         version,
+		Version:         semVersion,
 		URI:             tarballURL,
 		SHA256:          dependencySHA,
 		ReleaseDate:     &release.PublishedDate,
@@ -98,4 +112,15 @@ func (t Tini) createDependencyVersion(version string, release internal.GithubRel
 		PURL:            t.purlGenerator.Generate("tini", version, dependencySHA, tarballURL),
 		Licenses:        licenses,
 	}, nil
+}
+
+// If a user passes in the semantic version rather than the official vX.X.X
+// version, the GetDependencyVersion function will fail since we can't easily
+// query the Tini release pages
+func convertToTiniVersion(version string) string {
+	// add a `v` prefix
+	if !strings.Contains(version, "v") {
+		version = "v" + version
+	}
+	return version
 }

--- a/pkg/dependency/yarn.go
+++ b/pkg/dependency/yarn.go
@@ -47,7 +47,7 @@ func (y Yarn) GetAllVersionRefs() ([]string, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse version: %w", err)
 		}
-		/** Versions less than 0.7.0 does not have source code and the version tag does not contains the "v" at the start*/
+		/** Versions less than 0.7.0 do not have source code and the version tag does not contains the "v" at the start*/
 		if version.LessThan(semver.MustParse("0.7.0")) {
 			continue
 		}
@@ -147,8 +147,13 @@ func (y Yarn) createDependencyVersion(version, tagName string, release internal.
 		return DepVersion{}, fmt.Errorf("could not get retrieve licenses: %w", err)
 	}
 
+	semVersion, err := convertToSemVer(version)
+	if err != nil {
+		return DepVersion{}, err
+	}
+
 	return DepVersion{
-		Version:         version,
+		Version:         semVersion,
 		URI:             asset.BrowserDownloadUrl,
 		SHA256:          dependencySHA,
 		ReleaseDate:     &release.PublishedDate,


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Resolves part of #53, makes Go and other dependencies have semantic versions in the dep-server metadata. It does not address the part of issue #53 that requests a JSON feed be used for Go. That will be addressed in a separate PR.

This change has notable effects on the following dependencies:`go`, `curl`, `icu`, `node`, `pip`, and `tini`. It makes the output version of the `GetDependencyVersion` function semver-compatible in the dep-server metadata. These are the only dependencies in the dep-server currently that do not have semantic versions.

This PR also includes the same `convertToSemver` step on all other dependencies, but has no effect because all other versions are already semantic versioned, but it's just not enforced.

Once this PR is merged, we should run the `build and upload` workflow for every version of the non-semantic dependencies mentioned above, so that their version metadata is updated.

## Implementation details

 * The `known-version` JSON file in GCP **does not** need modification with this implementation, because the `GetAllVersionRefs` functions have been left to get the versions as they appear on the official package release page. We just convert the version to a semantic version in `GetDependencyVersion`.

* Additionally, depending on the code in some of the dependencies, I have added a `convertTo<Dependency>Version` function, which converts a given version **back** into the official dependency version. For example in pkg/dependency/go.go, [this function](https://github.com/paketo-buildpacks/dep-server/blob/a31538dbcc17dfca5674c3e9acab2b5b2117dc3f/pkg/dependency/go.go#L237) converts `1.16.0` into `go1.16`, because the rest of the code in this function needs the **official** version in order to query release pages. This function has been added as a safeguarding mechanism since the `GetDependencyVersion` function can be run two ways. If it gets run through our full automation pipeline, it will receive the official `go1.16` version from the `GetAllVersionRefs` function as expected. If it gets run through a manual triggering of the `Build and Upload` workflow, and a user passes in the semantic version `1.16.0` since that will be what is in the dep-server, we must convert the version into an official version.

* The nature of the versioning is not consistent across dependencies, so this extra "back conversion" step has only been added to the dependencies that have clear non-semantic official versions (such as Go). Dependencies such as `curl` have semantic and non-semantic versions available, so it's not possible to implement this safeguard. There's no way to safeguard in these cases because the official version is already semantic in many cases.


## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
