### PR TITLE
Add single quotes around licenses variable so it's not an array

### DIFF
--- a/.github/workflows/tini-test-upload-metadata.yml
+++ b/.github/workflows/tini-test-upload-metadata.yml
@@ -40,4 +40,4 @@ jobs:
         source-sha256: ${{ github.event.client_payload.source_sha256 }}
         deprecation-date: ${{ github.event.client_payload.deprecation_date }}
         cpe: ${{ steps.modify-cpe.outputs.cpe }}
-        licenses: ${{ github.event.client_payload.licenses }}
+        licenses: '${{ github.event.client_payload.licenses }}'


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

May alleviate the error in https://github.com/paketo-buildpacks/dep-server/runs/3067591929?check_suite_focus=true in which the licenses variable is an unexpected array. Wrapping it in single quotes should join the whole array as a single item.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
