### PR TITLE
build-upload test: single quote around licenses

### DIFF
--- a/.github/workflows/tini-build-upload.yml
+++ b/.github/workflows/tini-build-upload.yml
@@ -59,6 +59,11 @@ jobs:
       run: |
         cpe="$(echo '${{ steps.upstream.outputs.cpe }}' | sed 's|\\|\\\\|g')"
         echo "::set-output name=cpe::${cpe}"
+    - name: Flatten Licenses
+      id: flatten-licenses
+      run: |
+        licenses="$(echo '${{ steps.upstream.outputs.licenses }}' | sed -e 's/"//g' -e 's/[][]//g')"
+        echo "::set-output name=licenses::${licenses}"
     - name: Trigger Tests
       uses: paketo-buildpacks/github-config/actions/dispatch@main
       with:
@@ -74,5 +79,5 @@ jobs:
             "source_sha256": "${{ steps.upstream.outputs.sha256 }}",
             "deprecation_date": "${{ steps.upstream.outputs.deprecation-date }}",
             "cpe": "${{ steps.modify-cpe.outputs.cpe }}",
-            "licenses": '${{ steps.upstream.outputs.licenses }}'
+            "licenses": "${{ steps.flatten-licenses.outputs.licenses }}"
           }

--- a/.github/workflows/tini-build-upload.yml
+++ b/.github/workflows/tini-build-upload.yml
@@ -74,5 +74,5 @@ jobs:
             "source_sha256": "${{ steps.upstream.outputs.sha256 }}",
             "deprecation_date": "${{ steps.upstream.outputs.deprecation-date }}",
             "cpe": "${{ steps.modify-cpe.outputs.cpe }}",
-            "licenses": ${{ steps.upstream.outputs.licenses }}
+            "licenses": '${{ steps.upstream.outputs.licenses }}'
           }

--- a/actions/upload-metadata/action.yml
+++ b/actions/upload-metadata/action.yml
@@ -75,8 +75,8 @@ runs:
           "deprecation_date": "${{ inputs.deprecation-date }}",
           "created_at": "${created_at}",
           "modified_at": "${now}",
-          "cpe": "${cpe}"
-          "licenses": "${{ inputs.licenses }}",
+          "cpe": "${cpe}",
+          "licenses": "${{ inputs.licenses }}"
         }
         EOF
         )"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Similar to #73, this may alleviate the error https://github.com/paketo-buildpacks/dep-server/actions/runs/1030731890 in which the licenses variable is an unexpected array. Wrapping it in single quotes should join the whole array as a single item.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
