### PR TITLE
remove extra EOF from metadata JSON

### DIFF
--- a/actions/upload-metadata/action.yml
+++ b/actions/upload-metadata/action.yml
@@ -78,7 +78,6 @@ runs:
           "cpe": "${cpe}"
           "licenses": "${{ inputs.licenses }}",
         }
-        EOF
         )"
 
         updated_metadata="$(jq \


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

The`EOF` present in the metadata to upload is somehow causing the `jq` command on line 83 below to fail as you can see in https://github.com/paketo-buildpacks/dep-server/actions/runs/1031053919. Removing this should make the JSON valid for the command.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
