### PR TITLE
Flatten licenses array in workflows, unflatten into array during upload

### DIFF
--- a/.github/templates/build-upload.yml
+++ b/.github/templates/build-upload.yml
@@ -72,6 +72,12 @@ jobs:
         cpe="$(echo '${{ steps.upstream.outputs.cpe }}' | sed 's|\\|\\\\|g')"
         echo "::set-output name=cpe::${cpe}"
 
+    - name: Flatten Licenses
+      id: flatten-licenses
+      run: |
+        licenses="$(echo '${{ steps.upstream.outputs.licenses }}' | sed -e 's/"//g' -e 's/[][]//g')"
+        echo "::set-output name=licenses::${licenses}"
+
     - name: Trigger Tests
       uses: paketo-buildpacks/github-config/actions/dispatch@main
       with:
@@ -87,5 +93,5 @@ jobs:
             "source_sha256": "${{ steps.upstream.outputs.sha256 }}",
             "deprecation_date": "${{ steps.upstream.outputs.deprecation-date }}",
             "cpe": "${{ steps.modify-cpe.outputs.cpe }}",
-            "licenses": ${{ steps.upstream.outputs.licenses }}
+            "licenses": "${{ steps.flatten-licenses.outputs.licenses }}"
           }

--- a/.github/workflows/tini-test-upload-metadata.yml
+++ b/.github/workflows/tini-test-upload-metadata.yml
@@ -40,4 +40,4 @@ jobs:
         source-sha256: ${{ github.event.client_payload.source_sha256 }}
         deprecation-date: ${{ github.event.client_payload.deprecation_date }}
         cpe: ${{ steps.modify-cpe.outputs.cpe }}
-        licenses: '${{ github.event.client_payload.licenses }}'
+        licenses: ${{ github.event.client_payload.licenses }}

--- a/actions/upload-metadata/action.yml
+++ b/actions/upload-metadata/action.yml
@@ -63,6 +63,8 @@ runs:
 
         cpe="$(echo '${{ inputs.cpe }}' | sed 's|\\|\\\\|g')"
 
+        licenses="$(echo '${{ inputs.licenses }}' | jq -Rc 'split(",")')"
+
         metadata="$(cat << EOF
         {
           "name": "${{ inputs.dependency-name }}",
@@ -76,7 +78,7 @@ runs:
           "created_at": "${created_at}",
           "modified_at": "${now}",
           "cpe": "${cpe}",
-          "licenses": "${{ inputs.licenses }}"
+          "licenses": "${licenses}"
         }
         EOF
         )"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

* Adds a step in build-upload to flatten licenses so that we can pass them amongst workflows
* Remove unncessary single quotes from test-upload licenses, because it can be treated like a normal string arg.
* Un-flatten the string of licenses when we upload the license metadata to the dep-server so that the licenses will appear as an array, rather than a comma-separated string

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
