### PR TITLE
Add new workflow that updates go.sum files

### DIFF
--- a/.github/workflows/auto-update-go-sum.yml
+++ b/.github/workflows/auto-update-go-sum.yml
@@ -29,6 +29,9 @@ jobs:
           cd "${{ github.workspace }}/actions/list-new-upstream-dependency-versions/entrypoint"
           go mod tidy
 
+          cd "${{ github.workspace }}/pkg/dependency/tests/acceptance"
+          go mod tidy
+
       - name: Commit
         id: commit
         uses: paketo-buildpacks/github-config/actions/pull-request/create-commit@main

--- a/.github/workflows/update-go-sum.yml
+++ b/.github/workflows/update-go-sum.yml
@@ -1,0 +1,51 @@
+name: Auto update go.sum files
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '**.mod'
+  workflow_dispatch: { }
+
+jobs:
+  auto-update-go-sum:
+    name: Auto update go.sum
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Checkout Branch
+        uses: paketo-buildpacks/github-config/actions/pull-request/checkout-branch@main
+        with:
+          branch: automation/actions/update-go-sum
+
+      - name:
+        run: |
+          cd "${{ github.workspace }}/actions/get-upstream-dependency/entrypoint"
+          go mod tidy
+
+          cd "${{ github.workspace }}/actions/list-new-upstream-dependency-versions/entrypoint"
+          go mod tidy
+
+      - name: Commit
+        id: commit
+        uses: paketo-buildpacks/github-config/actions/pull-request/create-commit@main
+        with:
+          message: "Update go.sum files"
+          pathspec: "**/*go.sum"
+
+      - name: Push Branch
+        if: ${{ steps.commit.outputs.commit_sha != '' }}
+        uses: paketo-buildpacks/github-config/actions/pull-request/push-branch@main
+        with:
+          branch: automation/actions/update-go-sum
+
+      - name: Open Pull Request
+        if: ${{ steps.commit.outputs.commit_sha != '' }}
+        uses: paketo-buildpacks/github-config/actions/pull-request/open@main
+        with:
+          token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+          title: "Update go.sum files"
+          branch: automation/actions/update-go-sum


### PR DESCRIPTION
## Summary
When `dependabot` updates a new dependency it does not modify the `go.sum` files under `actions/get-upstream-dependency/entrypoint` and `actions/list-new-upstream-dependency-versions/entrypoint` that reference the `go.mod` in the root of the project so a problem is generated when one of these actions is used.

I create a new Workflow that updates these files when there is a change in the main `go.mod` file. 

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
