### PR TITLE
Fix typo in cd path

### DIFF
--- a/.github/workflows/auto-update-go-sum.yml
+++ b/.github/workflows/auto-update-go-sum.yml
@@ -34,7 +34,7 @@ jobs:
           cd "${{ github.workspace }}/actions/list-new-upstream-dependency-versions/entrypoint"
           go mod tidy
 
-          cd "${{ github.workspace }}/pkg/dependency/tests/acceptance"
+          cd "${{ github.workspace }}/pkg/dependency/test/acceptance"
           go mod tidy
 
       - name: Commit


### PR DESCRIPTION
Fix typo in cd path.

It should be `cd "${{ github.workspace }}/pkg/dependency/test/acceptance"` instead of cd `"${{ github.workspace }}/pkg/dependency/tests/acceptance"`


## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
