### PR TITLE
Add separate dependabot approval workflow

### DIFF
--- a/.github/workflows/approve-dependabot-pr.yml
+++ b/.github/workflows/approve-dependabot-pr.yml
@@ -1,0 +1,62 @@
+name: Approve Dependabot PRs
+
+on:
+  workflow_run:
+    workflows: ["Test Dep-Server"]
+    types:
+      - completed
+
+jobs:
+  download:
+    name: Download PR Artifact
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    outputs:
+      pr-author: ${{ steps.pr-data.outputs.author }}
+      pr-number: ${{ steps.pr-data.outputs.number }}
+    steps:
+      - name: 'Download artifact'
+        uses: paketo-buildpacks/github-config/actions/pull-request/download-artifact@main
+        with:
+          name: "event-payload"
+          repo: ${{ github.repository }}
+          run_id: ${{ github.event.workflow_run.id }}
+          workspace: "/github/workspace"
+          token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+      - id: pr-data
+        run: |
+          echo "::set-output name=author::$(cat event.json | jq -r '.pull_request.user.login')"
+          echo "::set-output name=number::$(cat event.json | jq -r '.pull_request.number')"
+
+  approve:
+    name: Auto Approve
+    needs: download
+    if: ${{ needs.download.outputs.pr-author == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check Commit Verification
+      id: unverified-commits
+      uses: paketo-buildpacks/github-config/actions/pull-request/check-unverified-commits@main
+      with:
+        token: ${{ secrets.PAKETO_BOT_REVIEWER_GITHUB_TOKEN }}
+        repo: ${{ github.repository }}
+        number: ${{ needs.download.outputs.pr-number }}
+
+    - name: Check for Human Commits
+      id: human-commits
+      uses: paketo-buildpacks/github-config/actions/pull-request/check-human-commits@main
+      with:
+        token: ${{ secrets.PAKETO_BOT_REVIEWER_GITHUB_TOKEN }}
+        repo: ${{ github.repository }}
+        number: ${{ needs.download.outputs.pr-number }}
+
+    - name: Checkout
+      if: steps.human-commits.outputs.human_commits == 'false' && steps.unverified-commits.outputs.unverified_commits == 'false'
+      uses: actions/checkout@v2
+
+    - name: Approve
+      if: steps.human-commits.outputs.human_commits == 'false' && steps.unverified-commits.outputs.unverified_commits == 'false'
+      uses: paketo-buildpacks/github-config/actions/pull-request/approve@main
+      with:
+        token: ${{ secrets.PAKETO_BOT_REVIEWER_GITHUB_TOKEN }}
+        number: ${{ needs.download.outputs.pr-number }}

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -10,11 +10,31 @@ jobs:
     if: ${{ github.event.pull_request.user.login == 'paketo-bot' }}
     runs-on: ubuntu-latest
     steps:
+    - name: Check Commit Verification
+      id: unverified-commits
+      uses: paketo-buildpacks/github-config/actions/pull-request/check-unverified-commits@main
+      with:
+        token: ${{ secrets.PAKETO_BOT_REVIEWER_GITHUB_TOKEN }}
+        repo: ${{ github.repository }}
+        number: ${{ github.event.number }}
+
+    - name: Check for Human Commits
+      id: human-commits
+      uses: paketo-buildpacks/github-config/actions/pull-request/check-human-commits@main
+      with:
+        token: ${{ secrets.PAKETO_BOT_REVIEWER_GITHUB_TOKEN }}
+        repo: ${{ github.repository }}
+        number: ${{ github.event.number }}
+
     - name: Checkout
+      if: steps.human-commits.outputs.human_commits == 'false' && steps.unverified-commits.outputs.unverified_commits == 'false'
       uses: actions/checkout@v2
 
     - name: Approve
+      if: steps.human-commits.outputs.human_commits == 'false' && steps.unverified-commits.outputs.unverified_commits == 'false'
       uses: paketo-buildpacks/github-config/actions/pull-request/approve@main
       with:
+        user: paketo-bot-reviewer
         token: ${{ secrets.PAKETO_BOT_REVIEWER_GITHUB_TOKEN }}
+        author: ${{ github.event.pull_request.user.login }}
         number: ${{ github.event.number }}

--- a/.github/workflows/test-dep-server.yml
+++ b/.github/workflows/test-dep-server.yml
@@ -32,17 +32,12 @@ jobs:
     - name: Run tests
       run: go test $(go list ./... | grep -v /pkg/dependency)
 
-  approve:
-    name: Auto Approve
-    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
-    needs: test
+  upload:
+    name: Upload Workflow Event Payload
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Approve
-      uses: paketo-buildpacks/github-config/actions/pull-request/approve@main
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v2
       with:
-        token: ${{ secrets.PAKETO_BOT_REVIEWER_GITHUB_TOKEN }}
-        number: ${{ github.event.number }}
+        name: event-payload
+        path: ${{ github.event_path }}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

The approval step in the workflows here fails on Dependabot PRs ([like this](https://github.com/paketo-buildpacks/dep-server/pull/97/checks?check_run_id=3158350121)) due to a change in GHA token permissions.

This PR adds a separate Dependabot approval workflow like we use for the rest of our repositories in paketo-buildpacks via [github-config](https://github.com/paketo-buildpacks/github-config/blob/main/implementation/.github/workflows/approve-bot-pr.yml).

This step doesn't include @paketo-bot PRs, because there already exists a separate workflow for those PRs which cover a slightly different use case. In this PR I added a check for human/unverified commits to the paketo-bot approval case as well.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
