### PR TITLE
Add GPG signing keys to paketo-bot commits so they are verified

### DIFF
--- a/.github/workflows/generate-dependency-workflows.yml
+++ b/.github/workflows/generate-dependency-workflows.yml
@@ -74,6 +74,8 @@ jobs:
       with:
         message: "Update dependency workflows"
         pathspec: ".github/workflows/"
+        keyid: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY_ID }}
+        key: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY }}
 
     - name: Push Branch
       if: ${{ steps.commit.outputs.commit_sha != '' }}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Add GPG keys to Paketo Bot commit so that the commit verification step in our auto-approval workflows will work. This is what we do in our[ github-config commit workflows](https://github.com/paketo-buildpacks/github-config/blob/3d6c03c00634d6bb1f0f6f7c32ee81a91048cd72/.github/workflows/update-tools.yml#L72-L79).

## Use Cases
<!-- An explanation of the use cases your change enables -->

Enable bot PR auto-approval

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
