### PR TITLE
Testing a workflow change to convert version to semver right before upload

### DIFF
--- a/.github/workflows/go-test-upload-metadata.yml
+++ b/.github/workflows/go-test-upload-metadata.yml
@@ -27,12 +27,17 @@ jobs:
       run: |
         cpe="$(echo '${{ github.event.client_payload.cpe }}' | sed 's|\\|\\\\|g')"
         echo "::set-output name=cpe::${cpe}"
+    - name: Convert Version to Semantic Version
+      id: semantic-version
+      uses: paketo-buildpacks/dep-server/actions/convert-semver@semver-workflow-change
+      with:
+        version: ${{ github.event.client_payload.version }}
     - name: Upload dependency metadata
       uses: paketo-buildpacks/dep-server/actions/upload-metadata@main
       with:
         bucket-name: ${{ secrets.DEPS_BUCKET }}
         dependency-name: ${{ env.DEP_NAME }}
-        version: ${{ github.event.client_payload.version }}
+        version: ${{ steps.semantic-version.outputs.sem-version }}
         sha256: ${{ github.event.client_payload.sha256 }}
         uri: ${{ github.event.client_payload.uri }}
         stacks: '[{"id":"io.buildpacks.stacks.bionic"},{"id":"io.paketo.stacks.tiny"}]'

--- a/actions/convert-semver/action.yml
+++ b/actions/convert-semver/action.yml
@@ -1,0 +1,34 @@
+name: 'Convert Version to Semantic Version'
+description: |
+ Takes a version and ensure it's in semantic version
+
+inputs:
+  version:
+    description: dependency version
+    required: true
+
+outputs:
+  sem-version:
+    description: semantic version
+    value: ${{ steps.convert-semver.outputs.sem-version }}
+
+runs:
+  using: 'composite'
+  steps:
+    - id: convert-semver
+      shell: bash
+      run: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        cd "${{ github.action_path }}/entrypoint"
+
+        go build -o ./entrypoint
+
+        metadata="$(./entrypoint \
+          --version "${{ inputs.version }}"
+        )"
+
+        echo "::set-output name=sem-version::$(jq -r .uri <<< "${metadata}")"
+
+        rm -f ./entrypoint

--- a/actions/convert-semver/entrypoint/main.go
+++ b/actions/convert-semver/entrypoint/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"regexp"
+
+	"github.com/Masterminds/semver"
+)
+
+func main() {
+	var (
+		version string
+	)
+
+	flag.StringVar(&version, "version", "", "Dependency version")
+	flag.Parse()
+
+	if version == "" {
+		fmt.Println("`version` is required")
+		os.Exit(1)
+	}
+
+	// Strip the any non-digit prefix off the version and ensure that the new
+	// version is semver-compatible
+	reg, err := regexp.Compile(`([0-9]+.?)+`)
+	if err != nil {
+		fmt.Println("could not compile regexp for conversion")
+		os.Exit(1)
+	}
+
+	semanticVersion, err := semver.NewVersion(reg.FindAllString(version, 1)[0])
+	if err != nil {
+		fmt.Println("could not convert to semantic version")
+		os.Exit(1)
+	}
+
+	fmt.Print(semanticVersion.String())
+}

--- a/actions/convert-semver/entrypoint/main_test.go
+++ b/actions/convert-semver/entrypoint/main_test.go
@@ -1,0 +1,80 @@
+package main_test
+
+import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/sclevine/spec"
+
+	"github.com/sclevine/spec/report"
+	assertpkg "github.com/stretchr/testify/assert"
+	requirepkg "github.com/stretchr/testify/require"
+)
+
+func TestEntrypoint(t *testing.T) {
+	spec.Run(t, "Entrypoint", testEntrypoint, spec.Report(report.Terminal{}))
+}
+
+func testEntrypoint(t *testing.T, when spec.G, it spec.S) {
+	var (
+		assert  = assertpkg.New(t)
+		require = requirepkg.New(t)
+		cliPath string
+	)
+
+	it.Before(func() {
+		tempFile, err := ioutil.TempFile("", "entrypoint")
+		require.NoError(err)
+		cliPath = tempFile.Name()
+		require.NoError(tempFile.Close())
+
+		goBuild := exec.Command("go", "build", "-o", cliPath, ".")
+		output, err := goBuild.CombinedOutput()
+		require.NoError(err, "failed to build CLI: %s", string(output))
+	})
+
+	it.After(func() {
+		_ = os.Remove(cliPath)
+	})
+
+	it("returns semantic version of the specified Go dependency version", func() {
+		version := "go1.15"
+
+		actualVersion, err := exec.Command(cliPath, "--version", version).CombinedOutput()
+		require.NoError(err, string(actualVersion))
+		assert.Equal("1.15.0", string(actualVersion))
+	})
+
+	when("given a major.minor version", func() {
+		it("returns the semantic version", func() {
+			version := "1.15"
+
+			actualVersion, err := exec.Command(cliPath, "--version", version).CombinedOutput()
+			require.NoError(err, string(actualVersion))
+			assert.Equal("1.15.0", string(actualVersion))
+		})
+	})
+
+	when("given a semantic version", func() {
+		it("returns the same version", func() {
+			version := "1.15.1"
+
+			actualVersion, err := exec.Command(cliPath, "--version", version).CombinedOutput()
+			require.NoError(err, string(actualVersion))
+			assert.Equal("1.15.1", string(actualVersion))
+		})
+	})
+
+	when("failure cases", func() {
+		when("the version cannot be converted into semver", func() {
+			it("exits status 1", func() {
+				version := "abc%"
+				_, err := exec.Command(cliPath, "--version", version).CombinedOutput()
+				assert.Error(err)
+			})
+		})
+	})
+
+}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Testing a theory that we can just convert the version to semver in the workflow before. If this works, I will put in another PR to roll out the changes workflow-wide

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
