### PR TITLE
remove unnecessary jq from semver conversion  action

### DIFF
--- a/actions/convert-semver/action.yml
+++ b/actions/convert-semver/action.yml
@@ -29,6 +29,6 @@ runs:
           --version "${{ inputs.version }}"
         )"
 
-        echo "::set-output name=sem-version::$(jq -r .uri <<< "${metadata}")"
+        echo "::set-output name=sem-version::"${metadata}""
 
         rm -f ./entrypoint


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

This was causing the version to show up as empty instead of a semver.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
