### PR TITLE
Semver conversion is test-upload workflow

### DIFF
--- a/.github/templates/test-upload-metadata.yml
+++ b/.github/templates/test-upload-metadata.yml
@@ -54,12 +54,18 @@ jobs:
         cpe="$(echo '${{ github.event.client_payload.cpe }}' | sed 's|\\|\\\\|g')"
         echo "::set-output name=cpe::${cpe}"
 
+    - name: Convert Version to Semantic Version
+      id: semantic-version
+      uses: paketo-buildpacks/dep-server/actions/convert-semver@main
+      with:
+        version: ${{ github.event.client_payload.version }}
+
     - name: Upload dependency metadata
       uses: paketo-buildpacks/dep-server/actions/upload-metadata@main
       with:
         bucket-name: "${{ secrets.DEPS_BUCKET }}"
         dependency-name: "${{ env.DEP_NAME }}"
-        version: "${{ github.event.client_payload.version }}"
+        version: "${{ steps.semantic-version.outputs.sem-version }}"
         sha256: "${{ github.event.client_payload.sha256 }}"
         uri: "${{ github.event.client_payload.uri }}"
         stacks: #@ data.values.stacks

--- a/pkg/dependency/bundler.go
+++ b/pkg/dependency/bundler.go
@@ -53,11 +53,6 @@ func (b Bundler) GetDependencyVersion(version string) (DepVersion, error) {
 		return DepVersion{}, fmt.Errorf("could not get retrieve licenses: %w", err)
 	}
 
-	semVersion, err := convertToSemVer(version)
-	if err != nil {
-		return DepVersion{}, err
-	}
-
 	for _, release := range bundlerReleases {
 		if release.Version == version {
 			releaseDate, err := time.Parse(time.RFC3339Nano, release.Date)
@@ -65,7 +60,7 @@ func (b Bundler) GetDependencyVersion(version string) (DepVersion, error) {
 				return DepVersion{}, fmt.Errorf("could not parse release date: %w", err)
 			}
 			return DepVersion{
-				Version:         semVersion,
+				Version:         version,
 				URI:             depURL,
 				SHA256:          release.SHA,
 				ReleaseDate:     &releaseDate,

--- a/pkg/dependency/composer.go
+++ b/pkg/dependency/composer.go
@@ -85,13 +85,8 @@ func (c Composer) createDependencyVersion(release internal.GithubRelease) (DepVe
 		return DepVersion{}, fmt.Errorf("could not find license metadata: %w", err)
 	}
 
-	semVersion, err := convertToSemVer(release.TagName)
-	if err != nil {
-		return DepVersion{}, err
-	}
-
 	return DepVersion{
-		Version:         semVersion,
+		Version:         release.TagName,
 		URI:             depURL,
 		SHA256:          sha,
 		ReleaseDate:     &release.PublishedDate,

--- a/pkg/dependency/curl.go
+++ b/pkg/dependency/curl.go
@@ -130,13 +130,8 @@ func (c Curl) createDependencyVersion(release CurlRelease) (DepVersion, error) {
 	depURL := c.dependencyURL(release)
 	licenses, err := c.licenseRetriever.LookupLicenses("curl", depURL)
 
-	semVersion, err := convertToSemVer(release.Version)
-	if err != nil {
-		return DepVersion{}, err
-	}
-
 	return DepVersion{
-		Version:     semVersion,
+		Version:     release.Version,
 		URI:         depURL,
 		SHA256:      sha,
 		ReleaseDate: &release.Date,

--- a/pkg/dependency/dep_factory.go
+++ b/pkg/dependency/dep_factory.go
@@ -2,10 +2,8 @@ package dependency
 
 import (
 	"fmt"
-	"regexp"
 	"time"
 
-	"github.com/Masterminds/semver"
 	"github.com/paketo-buildpacks/dep-server/pkg/dependency/internal"
 	"github.com/paketo-buildpacks/dep-server/pkg/dependency/licenses"
 	"github.com/paketo-buildpacks/dep-server/pkg/dependency/purl"
@@ -118,22 +116,6 @@ func (d DepFactory) SupportsDependency(name string) bool {
 	}
 
 	return true
-}
-
-// Strip the any non-digit prefix off the version and ensure that the new
-// version is semver-compatible
-func convertToSemVer(version string) (string, error) {
-	reg, err := regexp.Compile(`([0-9]+.?)+`)
-	if err != nil {
-		return "", err
-	}
-
-	semanticVersion, err := semver.NewVersion(reg.FindAllString(version, 1)[0])
-	if err != nil {
-		return "", err
-	}
-
-	return semanticVersion.String(), nil
 }
 
 func (d DepFactory) NewDependency(name string) (Dependency, error) {

--- a/pkg/dependency/dotnet.go
+++ b/pkg/dependency/dotnet.go
@@ -132,13 +132,8 @@ func (d dotnet) GetDependencyVersion(version string) (DepVersion, error) {
 		return DepVersion{}, fmt.Errorf("could not get licenses: %w", err)
 	}
 
-	semVersion, err := convertToSemVer(version)
-	if err != nil {
-		return DepVersion{}, err
-	}
-
 	depVersion := DepVersion{
-		Version:     semVersion,
+		Version:     version,
 		URI:         releaseFile.URL,
 		SHA256:      sha256,
 		ReleaseDate: releaseDate,

--- a/pkg/dependency/go.go
+++ b/pkg/dependency/go.go
@@ -56,13 +56,6 @@ func (g Go) GetAllVersionRefs() ([]string, error) {
 }
 
 func (g Go) GetDependencyVersion(version string) (DepVersion, error) {
-	// We expect an official Go version (ex. go1.16) to be passed in.
-	// Safeguard incase a non-official semver-compatible version is passed in (ex. 1.16.0)
-	version, err := convertToGoVersion(version)
-	if err != nil {
-		return DepVersion{}, fmt.Errorf("could not convert to Go version: %w", err)
-	}
-
 	goReleasesWithFiles, err := g.getGoReleasesWithFiles()
 	if err != nil {
 		return DepVersion{}, err
@@ -85,13 +78,8 @@ func (g Go) GetDependencyVersion(version string) (DepVersion, error) {
 		return DepVersion{}, fmt.Errorf("could not get retrieve licenses: %w", err)
 	}
 
-	semVersion, err := convertToSemVer(version)
-	if err != nil {
-		return DepVersion{}, err
-	}
-
 	return DepVersion{
-		Version:         semVersion,
+		Version:         version,
 		URI:             depURL,
 		SHA256:          sha,
 		ReleaseDate:     releaseDate,
@@ -229,24 +217,4 @@ func (g Go) getGoReleasesWithFiles() ([]GoReleaseWithFiles, error) {
 
 func (g Go) dependencyURL(version string) string {
 	return fmt.Sprintf("https://dl.google.com/go/%s.src.tar.gz", version)
-}
-
-// If a user passes in the semantic version rather than the goX.X.X version
-// The GetDependencyVersion function will fail since we can't easily query the
-// Go release pages
-func convertToGoVersion(version string) (string, error) {
-	// if trailing .0, remove it
-	reg, err := regexp.Compile(`\.0`)
-	if err != nil {
-		return "", err
-	}
-
-	version = reg.ReplaceAllString(version, "")
-
-	// add a `go` prefix
-	if !strings.Contains(version, "go") {
-		version = "go" + version
-	}
-
-	return version, nil
 }

--- a/pkg/dependency/go_test.go
+++ b/pkg/dependency/go_test.go
@@ -159,7 +159,7 @@ func testGo(t *testing.T, when spec.G, it spec.S) {
 			assert.Equal(1, fakeLicenseRetriever.LookupLicensesCallCount())
 			assert.Equal(1, fakePURLGenerator.GenerateCallCount())
 			expectedDep := dependency.DepVersion{
-				Version:         "1.13.9",
+				Version:         "go1.13.9",
 				URI:             "https://dl.google.com/go/go1.13.9.src.tar.gz",
 				SHA256:          "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
 				ReleaseDate:     &expectedReleaseDate,
@@ -204,7 +204,7 @@ func testGo(t *testing.T, when spec.G, it spec.S) {
 				assert.Equal(1, fakeLicenseRetriever.LookupLicensesCallCount())
 				assert.Equal(1, fakePURLGenerator.GenerateCallCount())
 				expectedDep := dependency.DepVersion{
-					Version:         "1.13.9",
+					Version:         "go1.13.9",
 					URI:             "https://dl.google.com/go/go1.13.9.src.tar.gz",
 					SHA256:          "some-source-sha",
 					ReleaseDate:     &expectedReleaseDate,
@@ -220,54 +220,6 @@ func testGo(t *testing.T, when spec.G, it spec.S) {
 
 				urlArg, dependencyPathDownloadArg, _ := fakeWebClient.DownloadArgsForCall(0)
 				assert.Equal("https://dl.google.com/go/go1.13.9.src.tar.gz", urlArg)
-
-				assert.Equal(dependencyPathDownloadArg, fakeChecksummer.GetSHA256ArgsForCall(0))
-			})
-		})
-
-		when("the version passed in is already semver", func() {
-			it("returns the right go version", func() {
-				fakeWebClient.GetReturnsOnCall(0, []byte(`
-[
-{"version": "go1.13", "files": [{"sha256": "", "kind": "source"}]}
-]`), nil)
-
-				fakeWebClient.GetReturnsOnCall(1, []byte(`
-<!DOCTYPE html>
-<html lang="en">
-	<h2 id="go1.13">go1.13 (released 2020-03-19)</h2>
-		<p>
-		go1.13
-		(released 2020-03-19)
-		</p>
-`), nil)
-
-				fakeChecksummer.GetSHA256Returns("some-source-sha", nil)
-				fakeLicenseRetriever.LookupLicensesReturns([]string{"MIT", "MIT-2"}, nil)
-				fakePURLGenerator.GenerateReturns("pkg:generic/go@go1.13?checksum=some-source-sha&download_url=https://dl.google.com/go")
-
-				actualDep, err := golang.GetDependencyVersion("1.13.0")
-				require.NoError(err)
-
-				assert.Equal(1, fakeLicenseRetriever.LookupLicensesCallCount())
-				assert.Equal(1, fakePURLGenerator.GenerateCallCount())
-				expectedDep := dependency.DepVersion{
-					Version:         "1.13.0",
-					URI:             "https://dl.google.com/go/go1.13.src.tar.gz",
-					SHA256:          "some-source-sha",
-					ReleaseDate:     &expectedReleaseDate,
-					DeprecationDate: nil,
-					CPE:             "cpe:2.3:a:golang:go:1.13:*:*:*:*:*:*:*",
-					PURL:            "pkg:generic/go@go1.13?checksum=some-source-sha&download_url=https://dl.google.com/go",
-					Licenses:        []string{"MIT", "MIT-2"},
-				}
-				assert.Equal(expectedDep, actualDep)
-
-				urlArg, _ := fakeWebClient.GetArgsForCall(0)
-				assert.Equal("https://golang.org/dl/?mode=json&include=all", urlArg)
-
-				urlArg, dependencyPathDownloadArg, _ := fakeWebClient.DownloadArgsForCall(0)
-				assert.Equal("https://dl.google.com/go/go1.13.src.tar.gz", urlArg)
 
 				assert.Equal(dependencyPathDownloadArg, fakeChecksummer.GetSHA256ArgsForCall(0))
 			})
@@ -308,7 +260,7 @@ func testGo(t *testing.T, when spec.G, it spec.S) {
 		go1.14.1
 		(released 2020/03/19)
 		</p>
-	<h2 id="go1.13">go1.13 (released 2019-09-03)</h2>
+	<h2 id="go1.13">go1.13 (released 2019-09/03)</h2>
 		<p>
 		go1.13.1
 		(released 2019-09-25)

--- a/pkg/dependency/httpd.go
+++ b/pkg/dependency/httpd.go
@@ -67,13 +67,8 @@ func (h Httpd) GetDependencyVersion(version string) (DepVersion, error) {
 		return DepVersion{}, fmt.Errorf("could not get retrieve licenses: %w", err)
 	}
 
-	semVersion, err := convertToSemVer(version)
-	if err != nil {
-		return DepVersion{}, err
-	}
-
 	return DepVersion{
-		Version:     semVersion,
+		Version:     version,
 		URI:         depURL,
 		SHA256:      sha,
 		ReleaseDate: &release.releaseDate,

--- a/pkg/dependency/icu.go
+++ b/pkg/dependency/icu.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -57,15 +56,7 @@ func (i ICU) GetDependencyVersion(version string) (DepVersion, error) {
 	}
 
 	for _, release := range releases {
-		// We expect an official ICU version (ex. 66.1) to be passed in.
-		// Safeguard against user passing in a non-official semveric version (ex. 66.1.0)
-		version, err := convertToICUVersion(version)
-		if err != nil {
-			return DepVersion{}, err
-		}
-
 		if tagToVersion(release.TagName) == version {
-
 			depVersion, err := i.createDependencyVersion(version, release)
 			if err != nil {
 				return DepVersion{}, fmt.Errorf("could not create ICU version: %w", err)
@@ -150,13 +141,8 @@ func (i ICU) createDependencyVersion(version string, release internal.GithubRele
 		return DepVersion{}, fmt.Errorf("could not get retrieve licenses: %w", err)
 	}
 
-	semVersion, err := convertToSemVer(version)
-	if err != nil {
-		return DepVersion{}, err
-	}
-
 	return DepVersion{
-		Version:         semVersion,
+		Version:         version,
 		URI:             asset.BrowserDownloadUrl,
 		SHA256:          dependencySHA,
 		ReleaseDate:     &release.CreatedDate,
@@ -203,19 +189,4 @@ func (i ICU) getAllVersions() ([]internal.GithubRelease, error) {
 		}
 	}
 	return prunedReleases, nil
-}
-
-// If a user passes in the semantic version rather than the official ICU version
-// The GetDependencyVersion function will fail since we can't easily query the
-// ICU release pages
-func convertToICUVersion(version string) (string, error) {
-	// if trailing .0, remove it
-	reg, err := regexp.Compile(`\.0`)
-	if err != nil {
-		return "", err
-	}
-
-	version = reg.ReplaceAllString(version, "")
-
-	return version, nil
 }

--- a/pkg/dependency/icu_test.go
+++ b/pkg/dependency/icu_test.go
@@ -110,7 +110,7 @@ func testICU(t *testing.T, when spec.G, it spec.S) {
 			assert.Equal(1, fakePURLGenerator.GenerateCallCount())
 			expectedReleaseDate := time.Date(2020, 03, 11, 17, 21, 07, 0, time.UTC)
 			expectedDep := dependency.DepVersion{
-				Version:         "66.1.0",
+				Version:         "66.1",
 				URI:             "some-source-url",
 				SHA256:          "some-source-sha",
 				ReleaseDate:     &expectedReleaseDate,
@@ -142,66 +142,6 @@ func testICU(t *testing.T, when spec.G, it spec.S) {
 			releaseAssetSignatureArg, _, gpgKeysArg := fakeChecksummer.VerifyASCArgsForCall(0)
 			assert.Equal("some-signature", releaseAssetSignatureArg)
 			assert.Equal([]string{"some-gpg-key"}, gpgKeysArg)
-		})
-
-		when("a non-official ICU semveric version is passed in", func() {
-			it("returns the correct ICU version", func() {
-				fakeGithubClient.GetReleaseTagsReturns([]internal.GithubRelease{
-					{TagName: "release-67-1", CreatedDate: time.Date(2020, 04, 22, 17, 49, 10, 0, time.UTC)},
-					{TagName: "release-66-1", CreatedDate: time.Date(2020, 03, 11, 17, 21, 07, 0, time.UTC)},
-					{TagName: "release-65-1", CreatedDate: time.Date(2020, 10, 02, 21, 30, 54, 0, time.UTC)},
-				}, nil)
-				assetUrlContent := `{"browser_download_url":"some-source-url", "key":"some_value"}`
-				fakeWebClient.GetReturnsOnCall(0, []byte("some-gpg-key"), nil)
-				fakeWebClient.GetReturnsOnCall(1, []byte(assetUrlContent), nil)
-				fakeGithubClient.GetReleaseAssetReturns([]byte("some-signature"), nil)
-				fakeGithubClient.DownloadReleaseAssetReturns("some-asset-url", nil)
-				fakeChecksummer.GetSHA256Returns("some-source-sha", nil)
-				fakeChecksummer.SplitPGPKeysReturns([]string{"some-gpg-key"})
-				fakeLicenseRetriever.LookupLicensesReturns([]string{"MIT", "MIT-2"}, nil)
-				fakePURLGenerator.GenerateReturns("pkg:generic/icu@66.1?checksum=some-source-sha&download_url=some-source-url")
-
-				actualDep, err := icu.GetDependencyVersion("66.1.0")
-				require.NoError(err)
-
-				assert.Equal(1, fakeLicenseRetriever.LookupLicensesCallCount())
-				assert.Equal(1, fakePURLGenerator.GenerateCallCount())
-				expectedReleaseDate := time.Date(2020, 03, 11, 17, 21, 07, 0, time.UTC)
-				expectedDep := dependency.DepVersion{
-					Version:         "66.1.0",
-					URI:             "some-source-url",
-					SHA256:          "some-source-sha",
-					ReleaseDate:     &expectedReleaseDate,
-					DeprecationDate: nil,
-					CPE:             `cpe:2.3:a:icu-project:international_components_for_unicode:66.1:*:*:*:*:c\/c\+\+:*:*`,
-					PURL:            "pkg:generic/icu@66.1?checksum=some-source-sha&download_url=some-source-url",
-					Licenses:        []string{"MIT", "MIT-2"},
-				}
-
-				assert.Equal(expectedDep, actualDep)
-
-				url, _ := fakeWebClient.GetArgsForCall(0)
-				assert.Equal("https://raw.githubusercontent.com/unicode-org/icu/master/KEYS", url)
-
-				orgArg, repoArg, versionArg, filenameArg, _ := fakeGithubClient.DownloadReleaseAssetArgsForCall(0)
-				assert.Equal("unicode-org", orgArg)
-				assert.Equal("icu", repoArg)
-				assert.Equal("release-66-1", versionArg)
-				assert.Equal("icu4c-66_1-src.tgz", filenameArg)
-
-				orgArg, repoArg, versionArg, filenameArg = fakeGithubClient.GetReleaseAssetArgsForCall(0)
-				assert.Equal("unicode-org", orgArg)
-				assert.Equal("icu", repoArg)
-				assert.Equal("release-66-1", versionArg)
-				assert.Equal("icu4c-66_1-src.tgz.asc", filenameArg)
-
-				assert.Equal("some-gpg-key", fakeChecksummer.SplitPGPKeysArgsForCall(0))
-
-				releaseAssetSignatureArg, _, gpgKeysArg := fakeChecksummer.VerifyASCArgsForCall(0)
-				assert.Equal("some-signature", releaseAssetSignatureArg)
-				assert.Equal([]string{"some-gpg-key"}, gpgKeysArg)
-			})
-
 		})
 
 		when("getting a version prior to 49", func() {

--- a/pkg/dependency/nginx.go
+++ b/pkg/dependency/nginx.go
@@ -49,13 +49,8 @@ func (n Nginx) GetDependencyVersion(version string) (DepVersion, error) {
 		return DepVersion{}, fmt.Errorf("could not get retrieve licenses: %w", err)
 	}
 
-	semVersion, err := convertToSemVer(version)
-	if err != nil {
-		return DepVersion{}, err
-	}
-
 	return DepVersion{
-		Version:         semVersion,
+		Version:         version,
 		URI:             dependencyURL,
 		SHA256:          sha,
 		ReleaseDate:     &tagCommit.Date,

--- a/pkg/dependency/node.go
+++ b/pkg/dependency/node.go
@@ -44,10 +44,6 @@ func (n Node) GetAllVersionRefs() ([]string, error) {
 }
 
 func (n Node) GetDependencyVersion(version string) (DepVersion, error) {
-	// We expect an official Node version (ex. v13.6.1) to be passed in.
-	// Safeguard against user passing in a non-official semveric version (ex. 13.6.1)
-	version = convertToNodeVersion(version)
-
 	nodeReleases, err := n.getAllReleases()
 	if err != nil {
 		return DepVersion{}, fmt.Errorf("could not get releases: %w", err)
@@ -122,13 +118,8 @@ func (n Node) createDepVersion(release NodeRelease, releaseSchedule ReleaseSched
 		return DepVersion{}, fmt.Errorf("could not get retrieve licenses: %w", err)
 	}
 
-	semVersion, err := convertToSemVer(release.Version)
-	if err != nil {
-		return DepVersion{}, err
-	}
-
 	return DepVersion{
-		Version:         semVersion,
+		Version:         release.Version,
 		URI:             depURL,
 		SHA256:          sha,
 		ReleaseDate:     &releaseDate,
@@ -198,15 +189,4 @@ func (n Node) dependencyURL(version string) string {
 
 func (n Node) shaFileURL(version string) string {
 	return fmt.Sprintf("https://nodejs.org/dist/%s/SHASUMS256.txt", version)
-}
-
-// If a user passes in the semantic version rather than the Node vX.X.X version
-// The GetDependencyVersion function will fail since we can't easily query the
-// Go release pages
-func convertToNodeVersion(version string) string {
-	// add a `v` prefix
-	if !strings.Contains(version, "v") {
-		version = "v" + version
-	}
-	return version
 }

--- a/pkg/dependency/node_test.go
+++ b/pkg/dependency/node_test.go
@@ -118,7 +118,7 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  node-v13.9.0.t
 			expectedReleaseDate := time.Date(2020, 02, 20, 0, 0, 0, 0, time.UTC)
 			expectedDeprecationDate := time.Date(2020, 06, 01, 0, 0, 0, 0, time.UTC)
 			expectedDep := dependency.DepVersion{
-				Version:         "13.9.0",
+				Version:         "v13.9.0",
 				URI:             "https://nodejs.org/dist/v13.9.0/node-v13.9.0.tar.gz",
 				SHA256:          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				ReleaseDate:     &expectedReleaseDate,
@@ -134,64 +134,6 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  node-v13.9.0.t
 			assert.Equal("https://nodejs.org/dist/index.json", urlArg)
 		})
 
-		when("a non-offical semveric version is passed in", func() {
-			it("returns the correct node version", func() {
-				fakeWebClient.GetReturnsOnCall(0, []byte(`
-[
- {"version": "v14.0.0", "date": "2020-01-30"},
- {"version": "v13.9.0", "date": "2020-02-20"},
- {"version": "v13.8.0", "date": "2020-02-20"}
-]`), nil)
-
-				fakeWebClient.GetReturnsOnCall(1, []byte(`
-{
- "v13": {
-   "start": "2019-10-22",
-   "maintenance": "2020-04-01",
-   "end": "2020-06-01"
- },
- "v14": {
-   "start": "2020-04-21",
-   "lts": "2020-10-20",
-   "maintenance": "2021-10-19",
-   "end": "2023-04-30",
-   "codename": ""
- }
-}`), nil)
-
-				fakeWebClient.GetReturnsOnCall(2, []byte(`
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  node-v13.9.0.tar.gz
-`), nil)
-
-				fakeLicenseRetriever.LookupLicensesReturns([]string{"MIT", "MIT-2"}, nil)
-				fakePURLGenerator.GenerateReturns("pkg:generic/node@v13.9.0?checksum=aaaaa&download_url=https://nodejs.org")
-
-				actualDep, err := node.GetDependencyVersion("13.9.0")
-
-				require.NoError(err)
-
-				assert.Equal(1, fakeLicenseRetriever.LookupLicensesCallCount())
-				assert.Equal(1, fakePURLGenerator.GenerateCallCount())
-				expectedReleaseDate := time.Date(2020, 02, 20, 0, 0, 0, 0, time.UTC)
-				expectedDeprecationDate := time.Date(2020, 06, 01, 0, 0, 0, 0, time.UTC)
-				expectedDep := dependency.DepVersion{
-					Version:         "13.9.0",
-					URI:             "https://nodejs.org/dist/v13.9.0/node-v13.9.0.tar.gz",
-					SHA256:          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-					ReleaseDate:     &expectedReleaseDate,
-					DeprecationDate: &expectedDeprecationDate,
-					CPE:             "cpe:2.3:a:nodejs:node.js:13.9.0:*:*:*:*:*:*:*",
-					PURL:            "pkg:generic/node@v13.9.0?checksum=aaaaa&download_url=https://nodejs.org",
-					Licenses:        []string{"MIT", "MIT-2"},
-				}
-
-				assert.Equal(expectedDep, actualDep)
-
-				urlArg, _ := fakeWebClient.GetArgsForCall(0)
-				assert.Equal("https://nodejs.org/dist/index.json", urlArg)
-			})
-
-		})
 		when("the major version is 0", func() {
 			it("pulls the correct release schedule", func() {
 				fakeWebClient.GetReturnsOnCall(0, []byte(`
@@ -220,7 +162,7 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  node-v0.8.0.ta
 				expectedReleaseDate := time.Date(2015, 01, 30, 0, 0, 0, 0, time.UTC)
 				expectedDeprecationDate := time.Date(2016, 06, 01, 0, 0, 0, 0, time.UTC)
 				expectedDep := dependency.DepVersion{
-					Version:         "0.8.0",
+					Version:         "v0.8.0",
 					URI:             "https://nodejs.org/dist/v0.8.0/node-v0.8.0.tar.gz",
 					SHA256:          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 					ReleaseDate:     &expectedReleaseDate,
@@ -260,7 +202,7 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  node-v13.9.0.t
 
 				expectedReleaseDate := time.Date(2020, 01, 30, 0, 0, 0, 0, time.UTC)
 				expectedDep := dependency.DepVersion{
-					Version:         "13.9.0",
+					Version:         "v13.9.0",
 					URI:             "https://nodejs.org/dist/v13.9.0/node-v13.9.0.tar.gz",
 					SHA256:          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 					ReleaseDate:     &expectedReleaseDate,

--- a/pkg/dependency/pecl.go
+++ b/pkg/dependency/pecl.go
@@ -70,13 +70,9 @@ func (p Pecl) GetDependencyVersion(version string) (DepVersion, error) {
 			if err != nil {
 				return DepVersion{}, fmt.Errorf("could not get retrieve licenses: %w", err)
 			}
-			semVersion, err := convertToSemVer(currVersion.Version)
-			if err != nil {
-				return DepVersion{}, err
-			}
 
 			return DepVersion{
-				Version:         semVersion,
+				Version:         currVersion.Version,
 				URI:             dependencyURL,
 				SHA256:          dependencySHA,
 				ReleaseDate:     currVersion.ReleaseDate,

--- a/pkg/dependency/php.go
+++ b/pkg/dependency/php.go
@@ -81,13 +81,8 @@ func (p Php) GetDependencyVersion(version string) (DepVersion, error) {
 		return DepVersion{}, fmt.Errorf("could not get retrieve licenses: %w", err)
 	}
 
-	semVersion, err := convertToSemVer(version)
-	if err != nil {
-		return DepVersion{}, err
-	}
-
 	return DepVersion{
-		Version:         semVersion,
+		Version:         version,
 		URI:             dependencyURL,
 		SHA256:          dependencySHA,
 		ReleaseDate:     releaseDate,

--- a/pkg/dependency/pypi.go
+++ b/pkg/dependency/pypi.go
@@ -53,14 +53,7 @@ func (p PyPi) GetDependencyVersion(version string) (DepVersion, error) {
 	}
 
 	for _, release := range releases {
-		// If the version passed in is not semantic, convert it since we are
-		// comparing to release.Version which will be semantic.
-		semVersion, err := convertToSemVer(version)
-		if err != nil {
-			return DepVersion{}, err
-		}
-
-		if release.Version == semVersion {
+		if release.Version == version {
 			return release, nil
 		}
 	}
@@ -131,13 +124,8 @@ func (p PyPi) getReleases() ([]DepVersion, error) {
 				return nil, fmt.Errorf("could not get retrieve licenses: %w", err)
 			}
 
-			semVersion, err := convertToSemVer(version)
-			if err != nil {
-				return nil, err
-			}
-
 			releases = append(releases, DepVersion{
-				Version:     semVersion,
+				Version:     version,
 				URI:         release.URL,
 				SHA256:      release.Digests["sha256"],
 				ReleaseDate: &uploadTime,

--- a/pkg/dependency/python.go
+++ b/pkg/dependency/python.go
@@ -59,13 +59,8 @@ func (p Python) GetDependencyVersion(version string) (DepVersion, error) {
 		return DepVersion{}, fmt.Errorf("could not get retrieve licenses: %w", err)
 	}
 
-	semVersion, err := convertToSemVer(version)
-	if err != nil {
-		return DepVersion{}, err
-	}
-
 	return DepVersion{
-		Version:         semVersion,
+		Version:         version,
 		URI:             sourceURI,
 		SHA256:          sha256,
 		ReleaseDate:     releaseDate,

--- a/pkg/dependency/ruby.go
+++ b/pkg/dependency/ruby.go
@@ -61,13 +61,9 @@ func (r Ruby) GetDependencyVersion(version string) (DepVersion, error) {
 			if err != nil {
 				return DepVersion{}, fmt.Errorf("could not parse release date: %w", err)
 			}
-			semVersion, err := convertToSemVer(version)
-			if err != nil {
-				return DepVersion{}, err
-			}
 
 			return DepVersion{
-				Version:         semVersion,
+				Version:         version,
 				URI:             depURL,
 				SHA256:          depSHA,
 				ReleaseDate:     &releaseDate,

--- a/pkg/dependency/rust.go
+++ b/pkg/dependency/rust.go
@@ -59,13 +59,8 @@ func (r Rust) GetDependencyVersion(version string) (DepVersion, error) {
 		return DepVersion{}, fmt.Errorf("could not get retrieve licenses: %w", err)
 	}
 
-	semVersion, err := convertToSemVer(version)
-	if err != nil {
-		return DepVersion{}, err
-	}
-
 	return DepVersion{
-		Version:         semVersion,
+		Version:         version,
 		URI:             dependencyURL,
 		SHA256:          sha,
 		ReleaseDate:     releaseDate,

--- a/pkg/dependency/test/acceptance/acceptance_test.go
+++ b/pkg/dependency/test/acceptance/acceptance_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -84,17 +83,7 @@ func testAcceptance(t *testing.T, when spec.G, it spec.S) {
 
 						depVersions = append(depVersions, depVersion)
 
-						// some versions from GetAllVersionRefs are not semver compatible
-						// but the depVersion version is.
-						// To check theyre equivalent versions: chop off any leading
-						// non-digit or period characters and convert to semVer
-						reg, err := regexp.Compile(`([0-9]+.?)+`)
-						require.NoError(err)
-						semVersion, err := semver.NewVersion(reg.FindAllString(version, 1)[0])
-						require.NoError(err, "Invalid Semantic Version")
-
-						assert.Equal(semVersion.String(), depVersion.Version)
-
+						assert.Equal(version, depVersion.Version)
 						assert.Len(depVersion.SHA256, 64, "SHA256 did not have 64 characters for %s %s", depName, version)
 						assert.NotEmpty(depVersion.URI)
 

--- a/pkg/dependency/tini_test.go
+++ b/pkg/dependency/tini_test.go
@@ -98,7 +98,7 @@ func testTini(t *testing.T, when spec.G, it spec.S) {
 			assert.Equal(1, fakePURLGenerator.GenerateCallCount())
 			expectedReleaseDate := time.Date(2020, 6, 27, 0, 0, 0, 0, time.UTC)
 			expectedDep := dependency.DepVersion{
-				Version:         "1.0.0",
+				Version:         "v1.0.0",
 				URI:             "some-tarball-url",
 				SHA256:          "some-source-sha",
 				ReleaseDate:     &expectedReleaseDate,
@@ -114,50 +114,6 @@ func testTini(t *testing.T, when spec.G, it spec.S) {
 			assert.Equal("krallin", orgArg)
 			assert.Equal("tini", repoArg)
 			assert.Equal("v1.0.0", versionArg)
-		})
-
-		when("passed a non-official semantic version", func() {
-			it("returns the correct tini version", func() {
-				fakeGithubClient.GetReleaseTagsReturns([]internal.GithubRelease{
-					{
-						TagName:       "v2.0.0",
-						PublishedDate: time.Date(2020, 6, 28, 0, 0, 0, 0, time.UTC),
-					},
-					{
-						TagName:       "v1.0.0",
-						PublishedDate: time.Date(2020, 6, 27, 0, 0, 0, 0, time.UTC),
-					},
-				}, nil)
-				fakeGithubClient.DownloadSourceTarballReturns("some-tarball-url", nil)
-
-				fakeChecksummer.GetSHA256Returns("some-source-sha", nil)
-				fakeLicenseRetriever.LookupLicensesReturns([]string{"MIT", "MIT-2"}, nil)
-				fakePURLGenerator.GenerateReturns("pkg:generic/tini@v1.0.0?checksum=some-source-sha&download_url=some-tarball-url")
-
-				actualDep, err := tini.GetDependencyVersion("1.0.0")
-				require.NoError(err)
-
-				assert.Equal(1, fakeLicenseRetriever.LookupLicensesCallCount())
-				assert.Equal(1, fakePURLGenerator.GenerateCallCount())
-				expectedReleaseDate := time.Date(2020, 6, 27, 0, 0, 0, 0, time.UTC)
-				expectedDep := dependency.DepVersion{
-					Version:         "1.0.0",
-					URI:             "some-tarball-url",
-					SHA256:          "some-source-sha",
-					ReleaseDate:     &expectedReleaseDate,
-					DeprecationDate: nil,
-					CPE:             "cpe:2.3:a:tini_project:tini:1.0.0:*:*:*:*:*:*:*",
-					PURL:            "pkg:generic/tini@v1.0.0?checksum=some-source-sha&download_url=some-tarball-url",
-					Licenses:        []string{"MIT", "MIT-2"},
-				}
-
-				assert.Equal(expectedDep, actualDep)
-
-				orgArg, repoArg, versionArg, _ := fakeGithubClient.DownloadSourceTarballArgsForCall(0)
-				assert.Equal("krallin", orgArg)
-				assert.Equal("tini", repoArg)
-				assert.Equal("v1.0.0", versionArg)
-			})
 		})
 	})
 

--- a/pkg/dependency/yarn.go
+++ b/pkg/dependency/yarn.go
@@ -47,7 +47,7 @@ func (y Yarn) GetAllVersionRefs() ([]string, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse version: %w", err)
 		}
-		/** Versions less than 0.7.0 do not have source code and the version tag does not contains the "v" at the start*/
+		/** Versions less than 0.7.0 does not have source code and the version tag does not contains the "v" at the start*/
 		if version.LessThan(semver.MustParse("0.7.0")) {
 			continue
 		}
@@ -147,13 +147,8 @@ func (y Yarn) createDependencyVersion(version, tagName string, release internal.
 		return DepVersion{}, fmt.Errorf("could not get retrieve licenses: %w", err)
 	}
 
-	semVersion, err := convertToSemVer(version)
-	if err != nil {
-		return DepVersion{}, err
-	}
-
 	return DepVersion{
-		Version:         semVersion,
+		Version:         version,
 		URI:             asset.BrowserDownloadUrl,
 		SHA256:          dependencySHA,
 		ReleaseDate:     &release.PublishedDate,


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Resolves the semantic versioning part of #53. This was previously thought to be solved by #55, but that implementation did not work at the acceptance test level (see [this failed workflow run](https://github.com/paketo-buildpacks/dep-server/runs/3365878755?check_suite_focus=true)) because the version at that point needs to match the _actual_ version due to the nature of the tests. The conversion to semVer needs to happen after the tests, because we only care about the version showing up in semVer in the metadata.

 This PR does two major things:
1. Adds a semver conversion step to the test-upload workflow. The action was added in a previous commit. This will essentially just convert the dependency version to semantic version right at the end of the full workflow path just for the metadata upload.  This was tested in the [go-test-upload workflow](https://github.com/paketo-buildpacks/dep-server/runs/3375698087?check_suite_focus=true) first.

2. Reverts all changes from https://github.com/paketo-buildpacks/dep-server/pull/55.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
