### PR TITLE
Support poetry

### DIFF
--- a/.github/data/dependencies.yml
+++ b/.github/data/dependencies.yml
@@ -60,6 +60,10 @@
   requires: python
   stacks:
     - id: io.buildpacks.stacks.bionic
+- name: poetry
+  requires: python
+  stacks:
+    - id: io.buildpacks.stacks.bionic
 - name: python
   stacks:
     - id: io.buildpacks.stacks.bionic

--- a/actions/test-dependency/dependency-tests/poetry/run
+++ b/actions/test-dependency/dependency-tests/poetry/run
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -euo pipefail
+
+extract_tarball_poetry() {
+  rm -rf poetry
+  mkdir poetry
+  tar -xf dependency/*.tgz -C poetry --wildcards ./poetry*.tar.gz
+  tar -xf poetry/poetry*.tar.gz -C poetry
+}
+
+extract_tarball_python() {
+  rm -rf python
+  mkdir python
+  tar -xf required_dependency/*.tgz -C python
+}
+
+set_ld_library_path() {
+  export LD_LIBRARY_PATH="$PWD/python/lib:${LD_LIBRARY_PATH:-}"
+}
+
+check_version() {
+  expected_version="$1"
+  actual_version="$(./python/bin/python ./poetry/poetry-*/setup.py --version)"
+  if [[ "${actual_version}" != "${expected_version}" ]]; then
+    echo "Version ${actual_version} does not match expected version ${expected_version}"
+    exit 1
+  fi
+}
+
+main() {
+  extract_tarball_poetry
+  extract_tarball_python
+  set_ld_library_path
+  check_version "$1"
+
+  echo "All tests passed!"
+}
+
+main "$@"

--- a/pkg/dependency/dep_factory.go
+++ b/pkg/dependency/dep_factory.go
@@ -224,7 +224,7 @@ func (d DepFactory) NewDependency(name string) (Dependency, error) {
 			licenseRetriever: d.licenseRetriever,
 			purlGenerator:    d.purlGenerator,
 		}, nil
-	case "pip", "pipenv":
+	case "pip", "pipenv", "poetry":
 		return PyPi{
 			productName:      name,
 			checksummer:      d.checksummer,


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Adds poetry to the list of dependencies supported by the dep-server. Poetry is a PyPi-type dependency and therefore falls into the same category in the dep-factory as `pip` and `pipenv`.

## Use Cases
Allows the new `poetry` buildpack to consume a dependency built and hosted by the dep-server

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
