### PR TITLE
Fix poetry dependency test

### DIFF
--- a/actions/test-dependency/dependency-tests/poetry/run
+++ b/actions/test-dependency/dependency-tests/poetry/run
@@ -3,10 +3,11 @@
 set -euo pipefail
 
 extract_tarball_poetry() {
+  version="$1"
   rm -rf poetry
   mkdir poetry
-  tar -xf dependency/*.tgz -C poetry --wildcards ./poetry*.tar.gz
-  tar -xf poetry/poetry*.tar.gz -C poetry
+  tar -xf dependency/*.tgz -C poetry --wildcards ./poetry-"${version}".tar.gz
+  tar -xf poetry/poetry-"${version}".tar.gz -C poetry
 }
 
 extract_tarball_python() {
@@ -21,7 +22,7 @@ set_ld_library_path() {
 
 check_version() {
   expected_version="$1"
-  actual_version="$(./python/bin/python ./poetry/poetry-*/setup.py --version)"
+  actual_version="$(./python/bin/python ./poetry/poetry-"${version}"/setup.py --version)"
   if [[ "${actual_version}" != "${expected_version}" ]]; then
     echo "Version ${actual_version} does not match expected version ${expected_version}"
     exit 1
@@ -29,7 +30,7 @@ check_version() {
 }
 
 main() {
-  extract_tarball_poetry
+  extract_tarball_poetry "$1"
   extract_tarball_python
   set_ld_library_path
   check_version "$1"


### PR DESCRIPTION
Poetry artifact has both `poetry-<version>.tar.gz` and `poetry-core-<core-version>.tar.gz` inside it so simply using `poetry-*` is not specific enough.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
