### PR TITLE
Update the source URL for PHP Dependency

### DIFF
--- a/pkg/dependency/php.go
+++ b/pkg/dependency/php.go
@@ -250,7 +250,7 @@ func (p Php) dependencyURL(release PhpRawRelease, version string) string {
 		return fmt.Sprintf("https://museum.php.net/php%s/php-%s.tar.gz", majorVersion, version)
 	}
 
-	return fmt.Sprintf("https://www.php.net/distributions/php-%s.tar.gz", version)
+	return fmt.Sprintf("https://github.com/php/web-php-distributions/raw/master/php-%s.tar.gz", version)
 }
 
 func (p Php) parseReleaseDate(date string) (*time.Time, error) {

--- a/pkg/dependency/php_test.go
+++ b/pkg/dependency/php_test.go
@@ -188,7 +188,7 @@ func testPhp(t *testing.T, when spec.G, it spec.S) {
 			expectedDeprecationDate := time.Date(2022, 11, 28, 0, 0, 0, 0, time.UTC)
 			expectedDepVersion := dependency.DepVersion{
 				Version:         "7.4.4",
-				URI:             "https://www.php.net/distributions/php-7.4.4.tar.gz",
+				URI:             "https://github.com/php/web-php-distributions/raw/master/php-7.4.4.tar.gz",
 				SHA256:          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				ReleaseDate:     &expectedReleaseDate,
 				DeprecationDate: &expectedDeprecationDate,
@@ -244,7 +244,7 @@ func testPhp(t *testing.T, when spec.G, it spec.S) {
 				expectedDeprecationDate := time.Date(2022, 11, 10, 0, 0, 0, 0, time.UTC)
 				expectedDepVersion := dependency.DepVersion{
 					Version:         "7.4.4",
-					URI:             "https://www.php.net/distributions/php-7.4.4.tar.gz",
+					URI:             "https://github.com/php/web-php-distributions/raw/master/php-7.4.4.tar.gz",
 					SHA256:          "some-sha256",
 					ReleaseDate:     &expectedReleaseDate,
 					DeprecationDate: &expectedDeprecationDate,
@@ -254,7 +254,7 @@ func testPhp(t *testing.T, when spec.G, it spec.S) {
 				assert.Equal(expectedDepVersion, actualDepVersion)
 
 				url, _, _ := fakeWebClient.DownloadArgsForCall(0)
-				assert.Equal("https://www.php.net/distributions/php-7.4.4.tar.gz", url)
+				assert.Equal("https://github.com/php/web-php-distributions/raw/master/php-7.4.4.tar.gz", url)
 
 				url, _ = fakeWebClient.GetArgsForCall(1)
 				assert.Equal("https://www.php.net/releases/index.php?json&version=7.4.*", url)
@@ -289,7 +289,7 @@ func testPhp(t *testing.T, when spec.G, it spec.S) {
 				expectedDeprecationDate := time.Date(2016, 05, 9, 0, 0, 0, 0, time.UTC)
 				expectedDepVersion := dependency.DepVersion{
 					Version:         "5.3.25",
-					URI:             "https://www.php.net/distributions/php-5.3.25.tar.gz",
+					URI:             "https://github.com/php/web-php-distributions/raw/master/php-5.3.25.tar.gz",
 					SHA256:          "some-sha256",
 					ReleaseDate:     &expectedReleaseDate,
 					DeprecationDate: &expectedDeprecationDate,
@@ -325,7 +325,7 @@ func testPhp(t *testing.T, when spec.G, it spec.S) {
 				expectedDeprecationDate := time.Date(2009, 8, 24, 0, 0, 0, 0, time.UTC)
 				expectedDepVersion := dependency.DepVersion{
 					Version:         "5.1.6",
-					URI:             "https://www.php.net/distributions/php-5.1.6.tar.gz",
+					URI:             "https://github.com/php/web-php-distributions/raw/master/php-5.1.6.tar.gz",
 					SHA256:          "some-sha256",
 					ReleaseDate:     &expectedReleaseDate,
 					DeprecationDate: &expectedDeprecationDate,


### PR DESCRIPTION
## Context
In early January 2022, the Commercial Buildpacks team realized that the URL from which our [automation](https://github.com/cloudfoundry/binary-builder/) (shared with Paketo) was downloading the PHP source code for the build was generating a `503 Service Temporarily Unavailable` error code.

After further investigation, we discovered that it was because the mirror from which we downloaded the source code was flagging us as `bots` when downloading and required a verification (weird, assuming that several people/companies use this mirror to download/make PHP builds via some automation).

`503 Response HTML:`

![image](https://user-images.githubusercontent.com/17348387/160932358-c34b5d53-1740-485b-83df-405337d53304.png)

### Proposed and applied solution
A comment was made on [this bug](https://bugs.php.net/bug.php?id=81056) on the PHP page but unfortunately, it has not been resolved, which led us to look for an official alternative as a mirror. That's why we found in the official PHP repository [`web-php-distributions`](https://github.com/php/web-php-distributions) the new mirror from which we would download the source code to compile it. 

The commit associated with this change is this: https://github.com/cloudfoundry/binary-builder/commit/835327120a332d419076fbb7f03e6c1c58a96eb9

## Proposed changes to `dep-server`
To be consistent with the changes made above, the URL displayed in the dep-server is wrong, as it shows an incorrect source URL. It should be updated pointing to the right source URL (GitHub one).


## Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
