### PR TITLE
Add CPE for poetry.

### DIFF
--- a/pkg/dependency/pypi.go
+++ b/pkg/dependency/pypi.go
@@ -118,6 +118,9 @@ func (p PyPi) getReleases() ([]DepVersion, error) {
 			if p.productName == "pip" {
 				cpe = fmt.Sprintf("cpe:2.3:a:pypa:pip:%s:*:*:*:*:python:*:*", version)
 			}
+			if p.productName == "poetry" {
+				cpe = "cpe:2.3:a:python-poetry:poetry:*:*:*:*:*:*:*:*"
+			}
 
 			licenses, err := p.licenseRetriever.LookupLicenses("pypi", release.URL)
 			if err != nil {

--- a/pkg/dependency/pypi_test.go
+++ b/pkg/dependency/pypi_test.go
@@ -147,12 +147,50 @@ func testPyPi(t *testing.T, when spec.G, it spec.S) {
 			assert.Equal("https://pypi.org/pypi/pip/json", urlArg)
 		})
 
-		when("the product is not pip", func() {
+		when("the product is poetry", func() {
+			it.Before(func() {
+				var err error
+				pypi, err = dependency.NewCustomDependencyFactory(fakeChecksummer, fakeFileSystem, fakeGithubClient, fakeWebClient, fakeLicenseRetriever, fakePURLGenerator).NewDependency("poetry")
+				require.NoError(err)
+			})
+
+			it("the CPE field is present", func() {
+				fakeWebClient.GetReturns([]byte(`{
+"releases": {
+  "1.0.0": [
+    {"packagetype": "sdist", "upload_time_iso_8601": "2010-01-01T00:00:00.000000Z", "digests": {"sha256": "some-sha256"}}
+  ],
+  "2.0.0": [
+    {"packagetype": "bdist_wheel", "upload_time_iso_8601": "2010-05-01T00:00:00.000000Z"},
+    {
+      "packagetype": "sdist",
+      "upload_time_iso_8601": "2010-05-01T00:00:00.000000Z",
+      "digests": {
+        "md5": "some-md5",
+        "sha256": "some-sha256"
+      },
+      "url": "some-url"
+    }
+  ],
+  "3.0.0": [
+    {"packagetype": "sdist", "upload_time_iso_8601": "2010-08-01T00:00:00.000000Z", "digests": {"sha256": "some-sha256"}}
+  ]
+}}`), nil)
+
+				actualDep, err := pypi.GetDependencyVersion("2.0.0")
+				require.NoError(err)
+
+				assert.Equal("cpe:2.3:a:python-poetry:poetry:*:*:*:*:*:*:*:*", actualDep.CPE)
+			})
+		})
+
+		when("the product is not pip or poetry", func() {
 			it.Before(func() {
 				var err error
 				pypi, err = dependency.NewCustomDependencyFactory(fakeChecksummer, fakeFileSystem, fakeGithubClient, fakeWebClient, fakeLicenseRetriever, fakePURLGenerator).NewDependency("pipenv")
 				require.NoError(err)
 			})
+
 			it("the CPE field is empty", func() {
 				fakeWebClient.GetReturns([]byte(`{
 "releases": {


### PR DESCRIPTION
## Summary
We do not have a CPE for Poetry, but we should.

Note: Poetry does not have a true CPE with versions on the NIST website - just a generic versionless CPE.

Also, I did not run the acceptance tests locally before pushing this PR because I wasn't sure what permissions the github token needed.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
