### PR TITLE
Generate CPEs for all python tooling.

### DIFF
--- a/pkg/dependency/pypi.go
+++ b/pkg/dependency/pypi.go
@@ -115,11 +115,15 @@ func (p PyPi) getReleases() ([]DepVersion, error) {
 			}
 
 			var cpe string
-			if p.productName == "pip" {
+			switch p.productName {
+			case "pip":
 				cpe = fmt.Sprintf("cpe:2.3:a:pypa:pip:%s:*:*:*:*:python:*:*", version)
-			}
-			if p.productName == "poetry" {
-				cpe = "cpe:2.3:a:python-poetry:poetry:*:*:*:*:*:*:*:*"
+			case "pipenv":
+				cpe = fmt.Sprintf("cpe:2.3:a:pypa:pipenv:%s:*:*:*:*:python:*:*", version)
+			case "poetry":
+				cpe = fmt.Sprintf("cpe:2.3:a:python-poetry:poetry:%s:*:*:*:*:python:*:*", version)
+			default:
+				// do nothing
 			}
 
 			licenses, err := p.licenseRetriever.LookupLicenses("pypi", release.URL)


### PR DESCRIPTION
## Summary
Following on from #152 - we realized that we need to add CPEs for the rest of the python tooling (i.e. `pipenv`). Also, we realized there is no reason not to add the version or the `python` specifier.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
