### PR TITLE
Split unit and acceptance

### DIFF
--- a/.github/workflows/test-dependency-library.yml
+++ b/.github/workflows/test-dependency-library.yml
@@ -22,8 +22,11 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v2
 
-    - name: Run unit and acceptance tests
-      run: cd pkg/dependency && go test ./... -v
+    - name: Run unit tests
+      run: ./scripts/unit.sh
+
+    - name: Run acceptance tests
+      run: ./scripts/acceptance.sh
       env:
         GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/pkg/dependency/acceptance/acceptance_test.go
+++ b/pkg/dependency/acceptance/acceptance_test.go
@@ -22,6 +22,10 @@ const githubAccessTokenEnvVar = "GITHUB_ACCESS_TOKEN"
 const versionsToTest = 2
 
 func TestAcceptance(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	if _, ok := os.LookupEnv(githubAccessTokenEnvVar); !ok {
 		t.Fatalf("Must set %s", githubAccessTokenEnvVar)
 	}

--- a/scripts/acceptance.sh
+++ b/scripts/acceptance.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+readonly PROGDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly DEPSERVERDIR="$(cd "${PROGDIR}/.." && pwd)"
+
+go test -v "${DEPSERVERDIR}"/pkg/dependency/acceptance

--- a/scripts/unit.sh
+++ b/scripts/unit.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+readonly PROGDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly DEPSERVERDIR="$(cd "${PROGDIR}/.." && pwd)"
+
+go test -short -v "${DEPSERVERDIR}"/...


### PR DESCRIPTION
Split unit and acceptance so they can be run separately, using the `./scripts/<suite>.sh` mechanism that buildpack authors are familiar with