### PR TITLE
Bump go version in workflows

### DIFF
--- a/.github/templates/build-upload.yml
+++ b/.github/templates/build-upload.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.16
+        go-version: 1.18
 
     - name: Set Env Vars
       run: |

--- a/.github/templates/get-new-versions.yml
+++ b/.github/templates/get-new-versions.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.16
+        go-version: 1.18
 
     - name: Turnstyle
       uses: softprops/turnstyle@v1


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Hopefully will resolve failures in workflows:
```
go: github.com/onsi/gomega@v1.19.0 requires
	github.com/onsi/ginkgo/v2@v2.1.3: missing go.sum entry; to add it:
	go mod download github.com/onsi/ginkgo/v2
```
This started ocurring when Golang was bumped to v1.18

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
