### PR TITLE
Add jammy tiny stack support to golang.

### DIFF
--- a/.github/workflows/go-test-upload-metadata.yml
+++ b/.github/workflows/go-test-upload-metadata.yml
@@ -40,7 +40,7 @@ jobs:
         version: ${{ steps.semantic-version.outputs.sem-version }}
         sha256: ${{ github.event.client_payload.sha256 }}
         uri: ${{ github.event.client_payload.uri }}
-        stacks: '[{"id":"io.buildpacks.stacks.bionic"},{"id":"io.paketo.stacks.tiny"}]'
+        stacks: '[{"id":"io.buildpacks.stacks.bionic"},{"id":"io.paketo.stacks.tiny"},{"id":"io.buildpacks.stacks.jammy.tiny"}]'
         source-uri: ${{ github.event.client_payload.source_uri }}
         source-sha256: ${{ github.event.client_payload.source_sha256 }}
         deprecation-date: ${{ github.event.client_payload.deprecation_date }}


### PR DESCRIPTION
## Summary

This PR adds the `jammy` `tiny` stack to `go` - which we have validated with a custom-built jammy tiny stack. There is no readily-available jammy tiny stack for CI or external consumption yet.

See also: https://github.com/paketo-buildpacks/go-dist/pull/402

Signed-off-by: Frankie Gallina-Jones <frankieg@vmware.com>

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
