### PR TITLE
Add other valid PGP keys to NGINX key validation

### DIFF
--- a/actions/get-upstream-dependency/entrypoint/main.go
+++ b/actions/get-upstream-dependency/entrypoint/main.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"log"
 	"os"
 
 	"github.com/paketo-buildpacks/dep-server/pkg/dependency"
@@ -28,8 +29,7 @@ func main() {
 
 	output, err := getDepVersion(githubToken, name, version)
 	if err != nil {
-		fmt.Printf("Error: %s", err.Error())
-		os.Exit(1)
+		log.Fatal(err)
 	}
 
 	fmt.Println(output)

--- a/pkg/dependency/nginx_test.go
+++ b/pkg/dependency/nginx_test.go
@@ -73,7 +73,10 @@ func testNginx(t *testing.T, when spec.G, it spec.S) {
 				Date: time.Date(2020, 06, 17, 0, 0, 0, 0, time.UTC),
 			}, nil)
 			fakeWebClient.GetReturnsOnCall(0, []byte("some-gpg-key"), nil)
-			fakeWebClient.GetReturnsOnCall(1, []byte("some-signature"), nil)
+			fakeWebClient.GetReturnsOnCall(1, []byte("other-gpg-key"), nil)
+			fakeWebClient.GetReturnsOnCall(2, []byte("another-gpg-key"), nil)
+			fakeWebClient.GetReturnsOnCall(3, []byte("yet-another-gpg-key"), nil)
+			fakeWebClient.GetReturnsOnCall(4, []byte("some-signature"), nil)
 			fakeChecksummer.GetSHA256Returns("some-source-sha", nil)
 			fakeLicenseRetriever.LookupLicensesReturns([]string{"MIT", "MIT-2"}, nil)
 			fakePURLGenerator.GenerateReturns("pkg:generic/nginx@1.0.0?checksum=some-source-sha&download_url=http://nginx.org")
@@ -98,13 +101,25 @@ func testNginx(t *testing.T, when spec.G, it spec.S) {
 
 			url, _ := fakeWebClient.GetArgsForCall(0)
 			assert.Equal("http://nginx.org/keys/mdounin.key", url)
+			url, _ = fakeWebClient.GetArgsForCall(1)
+			assert.Equal("http://nginx.org/keys/maxim.key", url)
+			url, _ = fakeWebClient.GetArgsForCall(2)
+			assert.Equal("http://nginx.org/keys/sb.key", url)
+			url, _ = fakeWebClient.GetArgsForCall(3)
+			assert.Equal("http://nginx.org/keys/thresh.key", url)
 
 			urlArg, _, _ := fakeWebClient.DownloadArgsForCall(0)
 			assert.Equal("http://nginx.org/download/nginx-1.0.0.tar.gz", urlArg)
 
 			releaseAssetSignatureArg, _, nginxGPGKeyArg := fakeChecksummer.VerifyASCArgsForCall(0)
 			assert.Equal("some-signature", releaseAssetSignatureArg)
-			assert.Equal([]string{"some-gpg-key"}, nginxGPGKeyArg)
+			assert.Equal([]string{
+				"some-gpg-key",
+				"other-gpg-key",
+				"another-gpg-key",
+				"yet-another-gpg-key",
+			},
+				nginxGPGKeyArg)
 		})
 	})
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
NGINX dependency build for 1.22.0 [failed](https://github.com/paketo-buildpacks/dep-server/actions/runs/2378473323) because the 1.22.0 release tarball is signed by a different PGP key than previous releases have been. I added the other PGP keys and clarified the logging.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
