### PR TITLE
Format template. Failing due to indentation error

### DIFF
--- a/.github/templates/get-new-versions.yml
+++ b/.github/templates/get-new-versions.yml
@@ -3,7 +3,7 @@ name: #@ data.values.name.capitalize() + " Get New Versions"
 
 #! "on" must be in quotes because it is a truthy in ytt
 "on":
-  workflow_dispatch: {}
+  workflow_dispatch: { }
   schedule:
     - cron: '0 * * * *'
 
@@ -17,74 +17,74 @@ jobs:
     name: Check for new versions
     runs-on: ubuntu-18.04
     steps:
-    - name: Check out code
-      uses: actions/checkout@v2
+      - name: Check out code
+        uses: actions/checkout@v2
 
-    - name: Setup Go
-      uses: actions/setup-go@v1
-      with:
-        go-version: 1.18
+      - name: Setup Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.18
 
-    - name: Turnstyle
-      uses: softprops/turnstyle@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Turnstyle
+        uses: softprops/turnstyle@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@v0
-      with:
-        project_id: ${{ secrets.GCP_PROJECT }}
-        service_account_key: ${{ secrets.GAE_KEY }}
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v0
+        with:
+          project_id: ${{ secrets.GCP_PROJECT }}
+          service_account_key: ${{ secrets.GAE_KEY }}
 
-    - name: Get Known Versions
-      id: known-versions
-      run: |
-        echo "::set-output name=known-versions::"$(gsutil cat "gs://${{ env.GCP_BUCKET }}/known-versions/${{ env.DEP_NAME }}.json")""
+      - name: Get Known Versions
+        id: known-versions
+        run: |
+          echo "::set-output name=known-versions::"$(gsutil cat "gs://${{ env.GCP_BUCKET }}/known-versions/${{ env.DEP_NAME }}.json")""
 
-    - name: Get New Versions
-      id: get-new-versions
-      uses: paketo-buildpacks/dep-server/actions/list-new-upstream-dependency-versions@main
-      with:
-        name: "${{ env.DEP_NAME }}"
-        github-token: "${{ secrets.GITHUB_TOKEN }}"
-        known-versions: '${{ steps.known-versions.outputs.known-versions }}'
+      - name: Get New Versions
+        id: get-new-versions
+        uses: paketo-buildpacks/dep-server/actions/list-new-upstream-dependency-versions@main
+        with:
+          name: "${{ env.DEP_NAME }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          known-versions: '${{ steps.known-versions.outputs.known-versions }}'
 
-    - name: Trigger Builds
-      run: |
-        new_versions='${{ steps.get-new-versions.outputs.new-versions }}'
-        for version in $(echo "${new_versions}" | jq -r .[]); do
-          curl -X POST \
-            https://api.github.com/repos/${GITHUB_REPOSITORY}/dispatches \
-            -H "Accept: application/vnd.github.everest-preview+json" \
-            -H "Content-Type: application/json" \
-            -H "Authorization: token ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}" \
-            -d "{ \
-                  \"event_type\": \"${{ env.DEP_NAME }}-build\", \
-                  \"client_payload\": { \
-                    \"data\": { \
-                      \"version\": \"${version}\" \
+      - name: Trigger Builds
+        run: |
+          new_versions='${{ steps.get-new-versions.outputs.new-versions }}'
+          for version in $(echo "${new_versions}" | jq -r .[]); do
+            curl -X POST \
+              https://api.github.com/repos/${GITHUB_REPOSITORY}/dispatches \
+              -H "Accept: application/vnd.github.everest-preview+json" \
+              -H "Content-Type: application/json" \
+              -H "Authorization: token ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}" \
+              -d "{ \
+                    \"event_type\": \"${{ env.DEP_NAME }}-build\", \
+                    \"client_payload\": { \
+                      \"data\": { \
+                        \"version\": \"${version}\" \
+                       } \
                      } \
-                   } \
-                 }"
-        done
+                   }"
+          done
 
-    - name: Update Known Versions
-      run: |
-        echo '${{ steps.get-new-versions.outputs.upstream-versions }}' > known_versions
-        gsutil cp known_versions "gs://${{ env.GCP_BUCKET }}/known-versions/${{ env.DEP_NAME }}.json"
+      - name: Update Known Versions
+        run: |
+          echo '${{ steps.get-new-versions.outputs.upstream-versions }}' > known_versions
+          gsutil cp known_versions "gs://${{ env.GCP_BUCKET }}/known-versions/${{ env.DEP_NAME }}.json"
 
-   - name: Notify Maintainers of Failures
-     if: ${{ failure() }}
-     uses: paketo-buildpacks/github-config/actions/issue/file@main
-     with:
-        token: "${{ secrets.GITHUB_TOKEN }}"
-        repo: "${{github.repository}}"
-        label: "workflow-failure"
-        comment_if_exists: true
-        issue_title: "Failed to Get New ${{ env.DEP_NAME }} Versions"
-        issue_body: "[Get New Versions
+      - name: Notify Maintainers of Failures
+        if: ${{ failure() }}
+        uses: paketo-buildpacks/github-config/actions/issue/file@main
+        with:
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          repo: "${{github.repository}}"
+          label: "workflow-failure"
+          comment_if_exists: true
+          issue_title: "Failed to Get New ${{ env.DEP_NAME }} Versions"
+          issue_body: "[Get New Versions
         workflow](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})
         failed to run. Please take a look to ensure new versions are picked
         up. (cc @paketo-buildpacks/dependencies-maintainers)"
-        comment_body: "Another failure occurred:
+          comment_body: "Another failure occurred:
         https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"


### PR DESCRIPTION
## Summary
Generate Dep Workflows [job](https://github.com/paketo-buildpacks/dep-server/actions/runs/2532366184) is failing to generate workflows due to some format error (indentation)


## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
