### PR TITLE
Update setup-gcloud action version in deploy-dep-server.yml workflow

### DIFF
--- a/.github/workflows/deploy-dep-server.yml
+++ b/.github/workflows/deploy-dep-server.yml
@@ -1,18 +1,18 @@
 name: Deploy Dep-Server
 
 on:
-  workflow_dispatch: {}
+  workflow_dispatch: { }
   push:
     branches: [ main ]
     paths-ignore:
-    - 'pkg/dependency/**'
-    - '.github/workflows/test-dependency-library.yml'
-    - '.github/workflows/generate-dependency-workflows.yml'
-    - '.github/workflows/*-get-new-versions.yml'
-    - '.github/workflows/*-build-upload.yml'
-    - '.github/workflows/*-test-upload-metadata.yml'
-    - '.github/templates/**'
-    - '.github/data/**'
+      - 'pkg/dependency/**'
+      - '.github/workflows/test-dependency-library.yml'
+      - '.github/workflows/generate-dependency-workflows.yml'
+      - '.github/workflows/*-get-new-versions.yml'
+      - '.github/workflows/*-build-upload.yml'
+      - '.github/workflows/*-test-upload-metadata.yml'
+      - '.github/templates/**'
+      - '.github/data/**'
 
 env:
   GAE_KEY: ${{ secrets.GAE_KEY }}
@@ -24,14 +24,13 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
 
-    - name: Check out code
-      uses: actions/checkout@v2
+      - name: Check out code
+        uses: actions/checkout@v2
 
-    - uses: google-github-actions/setup-gcloud@master
-      with:
-        version: '270.0.0'
-        service_account_key: ${{ secrets.GAE_KEY }}
-        project_id: ${{ secrets.GCP_PROJECT }}
+      - uses: google-github-actions/setup-gcloud@v0
+        with:
+          service_account_key: ${{ secrets.GAE_KEY }}
+          project_id: ${{ secrets.GCP_PROJECT }}
 
-    - name: Deploy Server
-      run: gcloud app deploy --quiet
+      - name: Deploy Server
+        run: gcloud app deploy --quiet


### PR DESCRIPTION
## Summary
`Deploy Dep Server` [action](https://github.com/paketo-buildpacks/dep-server/actions/workflows/deploy-dep-server.yml) has been failing for almost 3 months due to an update in the action `setup-gcloud` used in the job.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
