### PR TITLE
Add failure notification workflow steps to the other workflows

### DIFF
--- a/.github/templates/build-upload.yml
+++ b/.github/templates/build-upload.yml
@@ -96,3 +96,19 @@ jobs:
             "purl": "${{ steps.upstream.outputs.purl }}",
             "licenses": "${{ steps.flatten-licenses.outputs.licenses }}"
           }
+
+    - name: Notify Maintainers of Failures
+      if: ${{ failure() }}
+      uses: paketo-buildpacks/github-config/actions/issue/file@main
+      with:
+        token: "${{ secrets.GITHUB_TOKEN }}"
+        repo: "${{github.repository}}"
+        label: "workflow-failure"
+        comment_if_exists: true
+        issue_title: "Failed to Build/Upload ${{ env.DEP_NAME }}"
+        issue_body: "[Build and Upload
+      workflow](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})
+      failed to run. Please take a look to ensure the version in the workflow
+      is built and uploaded successfully. (cc @paketo-buildpacks/dependencies-maintainers)"
+        comment_body: "Another failure occurred:
+      https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"

--- a/.github/templates/test-upload-metadata.yml
+++ b/.github/templates/test-upload-metadata.yml
@@ -75,3 +75,20 @@ jobs:
         cpe: "${{ steps.modify-cpe.outputs.cpe }}"
         purl: "${{ github.event.client_payload.purl }}"
         licenses: "${{ github.event.client_payload.licenses }}"
+
+    - name: Notify Maintainers of Failures
+      if: ${{ failure() }}
+      uses: paketo-buildpacks/github-config/actions/issue/file@main
+      with:
+        token: "${{ secrets.GITHUB_TOKEN }}"
+        repo: "${{github.repository}}"
+        label: "workflow-failure"
+        comment_if_exists: true
+        issue_title: "Failed to Test and Upload Metadata for ${{ env.DEP_NAME }}"
+        issue_body: "[Test and Upload Metadata
+      workflow](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})
+      failed to run. Please take a look to ensure the version in the workflow
+      is tested and metadata is uploaded successfully. (cc
+      @paketo-buildpacks/dependencies-maintainers)"
+        comment_body: "Another failure occurred:
+      https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Adds failure notification workflow steps to the other two workflows for each dependency.


## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
