### PR TITLE
Make stacks metadata for dependencies dependent on version

### DIFF
--- a/.github/data/dependencies.yml
+++ b/.github/data/dependencies.yml
@@ -13,13 +13,22 @@
   requires: dotnet-sdk
   stacks:
     - id: io.buildpacks.stacks.bionic
+      version-constraint: "*"
+    - id: io.buildpacks.stacks.jammy
+      version-constraint: ">=6.*"
 - name: dotnet-runtime
   requires: dotnet-sdk
   stacks:
     - id: io.buildpacks.stacks.bionic
+      version-constraint: "*"
+    - id: io.buildpacks.stacks.jammy
+      version-constraint: ">=6.*"
 - name: dotnet-sdk
   stacks:
     - id: io.buildpacks.stacks.bionic
+      version-constraint: "*"
+    - id: io.buildpacks.stacks.jammy
+      version-constraint: ">=6.*"
 - name: go
   stacks:
     - id: io.buildpacks.stacks.bionic

--- a/.github/templates/test-upload-metadata.yml
+++ b/.github/templates/test-upload-metadata.yml
@@ -60,6 +60,13 @@ jobs:
       with:
         version: ${{ github.event.client_payload.version }}
 
+    - name: Get Stacks for Version
+      id: compatible-stacks
+      uses: paketo-buildpacks/dep-server/actions/get-compatible-stacks@main
+      with:
+        version: "${{ steps.semantic-version.outputs.sem-version }}"
+        stacks: #@ data.values.stacks
+
     - name: Upload dependency metadata
       uses: paketo-buildpacks/dep-server/actions/upload-metadata@main
       with:
@@ -68,7 +75,7 @@ jobs:
         version: "${{ steps.semantic-version.outputs.sem-version }}"
         sha256: "${{ github.event.client_payload.sha256 }}"
         uri: "${{ github.event.client_payload.uri }}"
-        stacks: #@ data.values.stacks
+        stacks: "${{ steps.compatible-stacks.outputs.compatible-stacks }}"
         source-uri: "${{ github.event.client_payload.source_uri }}"
         source-sha256: "${{ github.event.client_payload.source_sha256 }}"
         deprecation-date: "${{ github.event.client_payload.deprecation_date }}"

--- a/actions/get-compatible-stacks/Dockerfile
+++ b/actions/get-compatible-stacks/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:alpine
+
+COPY entrypoint /tmp/entrypoint
+RUN cd /tmp/entrypoint && go build -o /entrypoint .
+
+ENTRYPOINT ["/entrypoint"]
+
+

--- a/actions/get-compatible-stacks/action.yml
+++ b/actions/get-compatible-stacks/action.yml
@@ -1,0 +1,25 @@
+name: 'Get Stacks Compatible With Version'
+description: |
+  Takes a version and a list of stacks with version constraints and returns a
+  list of stacks that are compatible with the given version
+
+inputs:
+  version:
+    description: dependency version
+    required: true
+  stacks:
+    description: JSON array of stacks with version constraints
+    required: true
+
+outputs:
+  compatible-stacks:
+    description: JSON array of stacks that fulfill the version constraints
+
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+  - "--version"
+  - "${{ inputs.version }}"
+  - "--stacks"
+  - "${{ inputs.stacks }}"

--- a/actions/get-compatible-stacks/entrypoint/go.mod
+++ b/actions/get-compatible-stacks/entrypoint/go.mod
@@ -1,0 +1,5 @@
+module github.com/paketo-buildpacks/dep-server/actions/get-compatible-stacks/entrypoint
+
+go 1.18
+
+require github.com/Masterminds/semver v1.5.0

--- a/actions/get-compatible-stacks/entrypoint/go.sum
+++ b/actions/get-compatible-stacks/entrypoint/go.sum
@@ -1,0 +1,2 @@
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=

--- a/actions/get-compatible-stacks/entrypoint/main.go
+++ b/actions/get-compatible-stacks/entrypoint/main.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+
+	"github.com/Masterminds/semver"
+)
+
+type Stack struct {
+	ID                string   `json:"id"`
+	VersionConstraint string   `json:"version-constraint,omitempty"`
+	Mixins            []string `json:"mixins,omitempty"`
+}
+
+func main() {
+	var config struct {
+		Version    string
+		StacksJSON string
+	}
+
+	flag.StringVar(&config.StacksJSON,
+		"stacks",
+		"",
+		"JSON array of stack IDs with version constraints")
+	flag.StringVar(&config.Version,
+		"version",
+		"",
+		"Version of dependency")
+
+	flag.Parse()
+
+	if config.StacksJSON == "" {
+		config.StacksJSON = `[]`
+	}
+
+	var stacks []Stack
+	err := json.Unmarshal([]byte(config.StacksJSON), &stacks)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var result []Stack
+	for _, stack := range stacks {
+		if stack.VersionConstraint == "" {
+			result = append(result, Stack{ID: stack.ID, Mixins: stack.Mixins})
+			continue
+		}
+		c, err := semver.NewConstraint(stack.VersionConstraint)
+		if err != nil {
+			log.Fatal(err)
+		}
+		v, _ := semver.NewVersion(config.Version)
+		if err != nil {
+			log.Fatal(err)
+		}
+		compatible, msgs := c.Validate(v)
+		if compatible {
+			result = append(result, Stack{ID: stack.ID, Mixins: stack.Mixins})
+			continue
+		}
+		for _, m := range msgs {
+			log.Println(m)
+		}
+	}
+	output, err := json.Marshal(result)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if len(result) == 0 {
+		log.Fatal("No stacks compatible with this version")
+	}
+
+	log.Println("Output: ", string(output))
+	fmt.Printf("::set-output name=compatible-stacks::%s\n", string(output))
+}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
In the process of trying to [support Jammy Jellyfish in Paketo](https://github.com/paketo-buildpacks/rfcs/blob/da3339d071ffed23c3cd1b374a6bfcefdea7ac70/text/stacks/0004-jammy-jellyfish.md) we need to test whether existing dependencies are compatible with Jammy. I've found that [.NET 3.1 is not compatible with the Jammy Jellyfish](https://github.com/dotnet/core/issues/7038#issuecomment-1110377345), but .NET 6.0 is. For this reason, the `stacks` metadata for .NET dependencies must be more flexible; it must depend on the version of the dependency, not just the ID. I've updated the workflow template data schema and the `test-and-upload-metadata.yml` workflow to support this use case.

While this PR will ultimately generate a diff in all dependencies' `*-test-and-upload-metadata.yml`, it's intended not to change the behaviour of the metadata upload step EXCEPT for .NET dependencies; the output metadata for all other dependencies should look exactly the same. It also sets us up to add version constraints to other dependencies+stacks as needed, as we roll out Jammy support.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
