### PR TITLE
Allow for dependencies to not be compiled

### DIFF
--- a/.github/data/dependencies.yml
+++ b/.github/data/dependencies.yml
@@ -24,6 +24,7 @@
     - id: io.buildpacks.stacks.jammy
       version-constraint: ">=6.*"
 - name: dotnet-sdk
+  skip_compile: true
   stacks:
     - id: io.buildpacks.stacks.bionic
       version-constraint: "*"

--- a/.github/data/dependency-workflows-config.yml
+++ b/.github/data/dependency-workflows-config.yml
@@ -5,3 +5,4 @@ stacks:
 mixins:
 required_dependency:
 skip_test:
+skip_compile:

--- a/.github/templates/build-upload.yml
+++ b/.github/templates/build-upload.yml
@@ -42,6 +42,7 @@ jobs:
         version: "${{ env.VERSION }}"
         github-token: "${{ secrets.GITHUB_TOKEN }}"
 
+    #@ if data.values.skip_compile != 'true':
     - name: Build
       id: build
       uses: paketo-buildpacks/dep-server/actions/build-dependency@main
@@ -65,6 +66,7 @@ jobs:
         bucket-name: ${{ secrets.DEPS_BUCKET }}
         dependency-name: ${{ env.DEP_NAME }}
         artifact-path: "${{ github.workspace }}/${{ steps.build.outputs.artifact-path }}"
+    #@ end
 
     - name: Modify CPE for Dispatch
       id: modify-cpe
@@ -84,6 +86,7 @@ jobs:
         repos: paketo-buildpacks/dep-server
         token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
         event: #@ data.values.name + "-test"
+        #@ if data.values.skip_compile != 'true':
         payload: |
           {
             "version": "${{ env.VERSION }}",
@@ -96,6 +99,20 @@ jobs:
             "purl": "${{ steps.upstream.outputs.purl }}",
             "licenses": "${{ steps.flatten-licenses.outputs.licenses }}"
           }
+        #@ else:
+        payload: |
+          {
+            "version": "${{ env.VERSION }}",
+            "uri": "${{ steps.upstream.outputs.uri }}",
+            "sha256": "${{ steps.upstream.outputs.sha256 }}",
+            "source_uri": "${{ steps.upstream.outputs.uri }}",
+            "source_sha256": "${{ steps.upstream.outputs.sha256 }}",
+            "deprecation_date": "${{ steps.upstream.outputs.deprecation-date }}",
+            "cpe": "${{ steps.modify-cpe.outputs.cpe }}",
+            "purl": "${{ steps.upstream.outputs.purl }}",
+            "licenses": "${{ steps.flatten-licenses.outputs.licenses }}"
+          }
+        #@ end
 
     - name: Notify Maintainers of Failures
       if: ${{ failure() }}

--- a/.github/workflows/generate-dependency-workflows.yml
+++ b/.github/workflows/generate-dependency-workflows.yml
@@ -44,6 +44,7 @@ jobs:
           mixins="$(echo "${obj}" | jq -r '.stacks[] | select( .id == "io.buildpacks.stacks.bionic").mixins // empty' -c)"
           requires="$(echo "${obj}" | jq -r '.requires // empty')"
           skip_test="$(echo "${obj}" | jq -r '.skip_test // false')"
+          skip_compile="$(echo "${obj}" | jq -r '.skip_compile // false')"
 
           ytt \
             -f ".github/templates/get-new-versions.yml" \
@@ -55,6 +56,7 @@ jobs:
             -f ".github/templates/build-upload.yml" \
             -f ".github/data/dependency-workflows-config.yml" \
             -v name="${name}" \
+            -v skip_compile="${skip_compile}" \
             > ".github/workflows/${name}-build-upload.yml"
 
           ytt \


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

As a part of https://github.com/paketo-buildpacks/dotnet-core/issues/722, the SDK dependency should not be compiled anymore. Instead, it's URI and SHA256 should be the same as the upstream ones.

This PR does two things:
- provides a mechanism to allow dependencies to not be compiled
- marks the .NET SDK dependency as non-compiled.

I have tested the templating behaviour locally.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
