### PR TITLE
Add jammy base/full stack support to the go dependency

### DIFF
--- a/.github/data/dependencies.yml
+++ b/.github/data/dependencies.yml
@@ -33,6 +33,7 @@
   stacks:
     - id: io.buildpacks.stacks.bionic
     - id: io.paketo.stacks.tiny
+    - id: io.buildpacks.stacks.jammy
     - id: io.buildpacks.stacks.jammy.tiny
 - name: httpd
   stacks:


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
In order for the Go language family buildpack to run on the Jammy Base and Full stacks, the stack ID `io.buildpacks.stacks.jammy` needs to be added to the go dependency.

Since the Jammy Base build image contains a [superset](https://github.com/paketo-buildpacks/jammy-base-stack/blob/f2ae39f99918b407a6c89feaaad5864024982479/stack/stack.toml#L21) of the [packages in the Jammy Tiny build image](https://github.com/paketo-buildpacks/jammy-tiny-stack/blob/main/stack/stack.toml), and both are based on Ubuntu Jammy Jellyfish, I have confidence the go toolchain will work as expected on the Jammy Base/Full stacks.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
