### PR TITLE
Add Jammy to Pythonic dependencies

### DIFF
--- a/.github/data/dependencies.yml
+++ b/.github/data/dependencies.yml
@@ -72,18 +72,27 @@
     - id: io.buildpacks.stacks.bionic
       version-constraint: "*"
     - id: io.buildpacks.stacks.jammy
-      version-constraint: ">=3.10.5"
+      version-constraint: ">=22.1.2"
 - name: pipenv
   requires: python
   stacks:
     - id: io.buildpacks.stacks.bionic
+      version-constraint: "*"
+    - id: io.buildpacks.stacks.jammy
+      version-constraint: ">=2022.7.4"
 - name: poetry
   requires: python
   stacks:
     - id: io.buildpacks.stacks.bionic
+      version-constraint: "*"
+    - id: io.buildpacks.stacks.jammy
+      version-constraint: ">=1.1.13"
 - name: python
   stacks:
     - id: io.buildpacks.stacks.bionic
+      version-constraint: "*"
+    - id: io.buildpacks.stacks.jammy
+      version-constraint: ">=3.10.5"
 - name: ruby
   stacks:
     - id: io.buildpacks.stacks.bionic


### PR DESCRIPTION
Fix `pip` and add Jammy to `python`, `pipenv`, and `poetry`.