### PR TITLE
manually set uid and gid to 0 for build/test actions

### DIFF
--- a/actions/build-dependency/Dockerfile
+++ b/actions/build-dependency/Dockerfile
@@ -1,5 +1,10 @@
 FROM paketobuildpacks/build:full
 
+ARG cnb_uid=0
+ARG cnb_gid=0
+
+USER ${cnb_uid}:${cnb_gid}
+
 COPY entrypoint /entrypoint
 
 ENTRYPOINT ["/entrypoint"]

--- a/actions/test-dependency/Dockerfile
+++ b/actions/test-dependency/Dockerfile
@@ -1,5 +1,10 @@
 FROM paketobuildpacks/build:base
 
+ARG cnb_uid=0
+ARG cnb_gid=0
+
+USER ${cnb_uid}:${cnb_gid}
+
 COPY entrypoint /entrypoint
 COPY dependency-tests /dependency-tests
 ENTRYPOINT ["/entrypoint"]


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Resolves permissions-related issues in https://github.com/paketo-buildpacks/dep-server/issues/196 in which compilation fails due to permissions errors. This error also occurs for the Test action, which uses a stack image in its Dockerfile.


## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
