### PR TITLE
CPython is not Jammy compatible

### DIFF
--- a/.github/data/dependencies.yml
+++ b/.github/data/dependencies.yml
@@ -91,8 +91,6 @@
   stacks:
     - id: io.buildpacks.stacks.bionic
       version-constraint: "*"
-    - id: io.buildpacks.stacks.jammy
-      version-constraint: ">=3.10.5"
 - name: ruby
   stacks:
     - id: io.buildpacks.stacks.bionic


### PR DESCRIPTION
CPython (as built by dep-server) is not Jammy compatible, so let's remove that from the metadata