### PR TITLE
untarring SDK from any tar extension type

### DIFF
--- a/actions/test-dependency/dependency-tests/dotnet-aspnetcore/run
+++ b/actions/test-dependency/dependency-tests/dotnet-aspnetcore/run
@@ -5,8 +5,8 @@ set -euo pipefail
 extract_tarballs() {
   rm -rf dotnet-root
   mkdir dotnet-root
-  tar -xf dependency/*.tar.xz -C dotnet-root
-  tar -xf required_dependency/*.tar.xz -C dotnet-root
+  tar -xf dependency/*.tar.* -C dotnet-root
+  tar -xf required_dependency/*.tar.* -C dotnet-root
 }
 
 check_version() {

--- a/actions/test-dependency/dependency-tests/dotnet-runtime/run
+++ b/actions/test-dependency/dependency-tests/dotnet-runtime/run
@@ -5,8 +5,8 @@ set -euo pipefail
 extract_tarballs() {
   rm -rf dotnet-root
   mkdir dotnet-root
-  tar -xf dependency/*.tar.xz -C dotnet-root
-  tar -xf required_dependency/*.tar.xz -C dotnet-root
+  tar -xf dependency/*.tar.* -C dotnet-root
+  tar -xf required_dependency/*.tar.* -C dotnet-root
 }
 
 check_version() {

--- a/actions/test-dependency/dependency-tests/dotnet-sdk/run
+++ b/actions/test-dependency/dependency-tests/dotnet-sdk/run
@@ -5,7 +5,7 @@ set -euo pipefail
 extract_tarball() {
   rm -rf dotnet-sdk
   mkdir dotnet-sdk
-  tar -xf dependency/*.tar.xz -C dotnet-sdk
+  tar -xf dependency/*.tar.* -C dotnet-sdk
 }
 
 check_version() {


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

All 3 .NET dependency tests are failing:
* https://github.com/paketo-buildpacks/dep-server/issues/209
* https://github.com/paketo-buildpacks/dep-server/issues/208
* https://github.com/paketo-buildpacks/dep-server/issues/207

This is because in https://github.com/paketo-buildpacks/dep-server/pull/183/ we started pulling .NET SDK directly from upstream instead of compiling it. The tarball from upstream is not `tar.xz`, but a `tar.gz`, so the untarring code was failing.

This change generalizes the path we look for tar files in when untarring the dependencies in the tests.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
