### PR TITLE
Replace deprecated GHA ::set-output syntax

### DIFF
--- a/.github/templates/build-upload.yml
+++ b/.github/templates/build-upload.yml
@@ -72,13 +72,13 @@ jobs:
       id: modify-cpe
       run: |
         cpe="$(echo '${{ steps.upstream.outputs.cpe }}' | sed 's|\\|\\\\|g')"
-        echo "::set-output name=cpe::${cpe}"
+        echo "cpe=${cpe}" >> "$GITHUB_OUTPUT"
 
     - name: Flatten Licenses
       id: flatten-licenses
       run: |
         licenses="$(echo '${{ steps.upstream.outputs.licenses }}' | sed -e 's/"//g' -e 's/[][]//g')"
-        echo "::set-output name=licenses::${licenses}"
+        echo "licenses=${licenses}" >> "$GITHUB_OUTPUT"
 
     - name: Trigger Tests
       uses: paketo-buildpacks/github-config/actions/dispatch@main

--- a/.github/templates/get-new-versions.yml
+++ b/.github/templates/get-new-versions.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Get Known Versions
         id: known-versions
         run: |
-          echo "::set-output name=known-versions::"$(gsutil cat "gs://${{ env.GCP_BUCKET }}/known-versions/${{ env.DEP_NAME }}.json")""
+          echo "known-versions="$(gsutil cat "gs://${{ env.GCP_BUCKET }}/known-versions/${{ env.DEP_NAME }}.json")"" >> "$GITHUB_OUTPUT"
 
       - name: Get New Versions
         id: get-new-versions

--- a/.github/templates/test-upload-metadata.yml
+++ b/.github/templates/test-upload-metadata.yml
@@ -24,7 +24,7 @@ jobs:
       id: required-dependency
       run: |
         uri="$(curl -sL "https://api.deps.paketo.io/v1/dependency?name=${{ env.REQUIRED_DEP }}" | jq -r '. |= sort_by(.version) | reverse[0].uri')"
-        echo "::set-output name=uri::${uri}"
+        echo "uri=${uri}" >> "$GITHUB_OUTPUT"
     #@ end
 
     - name: Test
@@ -52,7 +52,7 @@ jobs:
       id: modify-cpe
       run: |
         cpe="$(echo '${{ github.event.client_payload.cpe }}' | sed 's|\\|\\\\|g')"
-        echo "::set-output name=cpe::${cpe}"
+        echo "cpe=${cpe}" >> "$GITHUB_OUTPUT"
 
     - name: Convert Version to Semantic Version
       id: semantic-version

--- a/.github/workflows/approve-dependabot-pr.yml
+++ b/.github/workflows/approve-dependabot-pr.yml
@@ -25,8 +25,8 @@ jobs:
           token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
       - id: pr-data
         run: |
-          echo "::set-output name=author::$(cat event.json | jq -r '.pull_request.user.login')"
-          echo "::set-output name=number::$(cat event.json | jq -r '.pull_request.number')"
+          echo "author=$(cat event.json | jq -r '.pull_request.user.login')" >> "$GITHUB_OUTPUT"
+          echo "number=$(cat event.json | jq -r '.pull_request.number')" >> "$GITHUB_OUTPUT"
 
   approve:
     name: Auto Approve

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -26,7 +26,7 @@ jobs:
             --location \
             --header "Authorization: token ${GITHUB_TOKEN}"
         )"
-        echo "::set-output name=mergeable_state::$(echo "${payload}" | jq -r -c .mergeable_state)"
+        echo "mergeable_state=$(echo "${payload}" | jq -r -c .mergeable_state)" >> "$GITHUB_OUTPUT"
 
     - name: Merge
       if: ${{ steps.pull_request.outputs.mergeable_state == 'clean' || steps.pull_request.outputs.mergeable_state == 'unstable' }}

--- a/actions/build-dependency/entrypoint
+++ b/actions/build-dependency/entrypoint
@@ -60,7 +60,7 @@ STACK="bionic" SKIP_COMMIT=true \
   ./buildpacks-ci/tasks/build-binary-new/build.rb
 
 sha256="$(cat dep-metadata/*.json | jq -r .sha256)"
-echo "::set-output name=sha256::${sha256}"
+echo "sha256=${sha256}" >> "$GITHUB_OUTPUT"
 
 artifact_path="$(ls artifacts/*)"
-echo "::set-output name=artifact-path::${artifact_path}"
+echo "artifact-path=${artifact_path}" >> "$GITHUB_OUTPUT"

--- a/actions/convert-semver/action.yml
+++ b/actions/convert-semver/action.yml
@@ -29,6 +29,6 @@ runs:
           --version "${{ inputs.version }}"
         )"
 
-        echo "::set-output name=sem-version::"${metadata}""
+        echo "sem-version="${metadata}"" >> "$GITHUB_OUTPUT"
 
         rm -f ./entrypoint

--- a/actions/get-compatible-stacks/entrypoint/go.mod
+++ b/actions/get-compatible-stacks/entrypoint/go.mod
@@ -2,4 +2,9 @@ module github.com/paketo-buildpacks/dep-server/actions/get-compatible-stacks/ent
 
 go 1.18
 
-require github.com/Masterminds/semver v1.5.0
+require (
+	github.com/Masterminds/semver v1.5.0
+	github.com/paketo-buildpacks/pipeline-builder v1.30.0
+)
+
+require github.com/Masterminds/semver/v3 v3.2.0 // indirect

--- a/actions/get-compatible-stacks/entrypoint/go.sum
+++ b/actions/get-compatible-stacks/entrypoint/go.sum
@@ -1,2 +1,6 @@
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
+github.com/Masterminds/semver/v3 v3.2.0 h1:3MEsd0SM6jqZojhjLWWeBY+Kcjy9i6MQAeY7YgDP83g=
+github.com/Masterminds/semver/v3 v3.2.0/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
+github.com/paketo-buildpacks/pipeline-builder v1.30.0 h1:rGo0pbuSCuFmogmQOnAKX2WQVg66uZqt9lcs4tQ+2G8=
+github.com/paketo-buildpacks/pipeline-builder v1.30.0/go.mod h1:7cnVFDnlk5q7kBQPtkd7De8LCxKRlhEmJHrlpHPG6tc=

--- a/actions/get-compatible-stacks/entrypoint/main.go
+++ b/actions/get-compatible-stacks/entrypoint/main.go
@@ -3,10 +3,10 @@ package main
 import (
 	"encoding/json"
 	"flag"
-	"fmt"
 	"log"
 
 	"github.com/Masterminds/semver"
+	"github.com/paketo-buildpacks/pipeline-builder/actions"
 )
 
 type Stack struct {
@@ -75,5 +75,7 @@ func main() {
 	}
 
 	log.Println("Output: ", string(output))
-	fmt.Printf("::set-output name=compatible-stacks::%s\n", string(output))
+	actions.Outputs{
+		"compatible-stacks": string(output),
+	}.Write()
 }

--- a/actions/get-upstream-dependency/action.yml
+++ b/actions/get-upstream-dependency/action.yml
@@ -55,12 +55,12 @@ runs:
           --version "${{ inputs.version }}"
         )"
 
-        echo "::set-output name=uri::$(jq -r .uri <<< "${metadata}")"
-        echo "::set-output name=sha256::$(jq -r .sha256 <<< "${metadata}")"
-        echo "::set-output name=release-date::$(jq -r '.release_date // empty' <<< "${metadata}")"
-        echo "::set-output name=deprecation-date::$(jq -r '.deprecation_date // empty' <<< "${metadata}")"
-        echo "::set-output name=cpe::$(jq -r .cpe <<< "${metadata}")"
-        echo "::set-output name=purl::$(jq -r .purl <<< "${metadata}")"
-        echo "::set-output name=licenses::$(jq -c .licenses <<< "${metadata}")"
+        echo "uri=$(jq -r .uri <<< "${metadata}")" >> "$GITHUB_OUTPUT"
+        echo "sha256=$(jq -r .sha256 <<< "${metadata}")" >> "$GITHUB_OUTPUT"
+        echo "release-date=$(jq -r '.release_date // empty' <<< "${metadata}")" >> "$GITHUB_OUTPUT"
+        echo "deprecation-date=$(jq -r '.deprecation_date // empty' <<< "${metadata}")" >> "$GITHUB_OUTPUT"
+        echo "cpe=$(jq -r .cpe <<< "${metadata}")" >> "$GITHUB_OUTPUT"
+        echo "purl=$(jq -r .purl <<< "${metadata}")" >> "$GITHUB_OUTPUT"
+        echo "licenses=$(jq -c .licenses <<< "${metadata}")" >> "$GITHUB_OUTPUT"
 
         rm -f ./entrypoint

--- a/actions/list-new-upstream-dependency-versions/action.yml
+++ b/actions/list-new-upstream-dependency-versions/action.yml
@@ -43,15 +43,8 @@ runs:
         new_versions="$(jq -n --argjson upstream_versions "${upstream_versions}" \
           --argjson known_versions '${{ inputs.known-versions }}' '$upstream_versions-$known_versions')"
 
-        upstream_versions="${upstream_versions//'%'/'%25'}"
-        upstream_versions="${upstream_versions//$'\n'/'%0A'}"
-        upstream_versions="${upstream_versions//$'\r'/'%0D'}"
-
-        new_versions="${new_versions//'%'/'%25'}"
-        new_versions="${new_versions//$'\n'/'%0A'}"
-        new_versions="${new_versions//$'\r'/'%0D'}"
-
-        echo "::set-output name=upstream-versions::${upstream_versions}"
-        echo "::set-output name=new-versions::${new_versions}"
+        delimiter=$(openssl rand -hex 16) # roughly the same entropy as uuid v4 used in https://github.com/actions/toolkit/blob/b36e70495fbee083eb20f600eafa9091d832577d/packages/core/src/file-command.ts#L28
+        printf "upstream-versions<<%s\n%s\n%s\n" "${delimiter}" "${upstream_versions}" "${delimiter}" >> "${GITHUB_OUTPUT}" # see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
+        printf "new-versions<<%s\n%s\n%s\n" "${delimiter}" "${new_versions}" "${delimiter}" >> "${GITHUB_OUTPUT}" # see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
 
         rm -f ./entrypoint

--- a/actions/upload-dependency/action.yml
+++ b/actions/upload-dependency/action.yml
@@ -32,4 +32,4 @@ runs:
         aws s3 cp '${{ inputs.artifact-path }}' "s3://${{ inputs.bucket-name }}/deps/${{ inputs.dependency-name }}/${filename}"
 
         uri="https://deps.paketo.io/${{ inputs.dependency-name }}/${filename}"
-        echo "::set-output name=uri::${uri}"
+        echo "uri=${uri}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Use the new way of producing outputs in a github action as the old way is deprecated and will be removed (31st May 2023).

See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

See also: https://github.com/paketo-buildpacks/github-config/pull/604

## Use Cases

Keep the pipelines alive.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
